### PR TITLE
fix(docs): Clarify `defineRollupSwcOption` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ export default {
 }
 ```
 
-If you want autocompletion in your IDE or type check:
+If you want autocompletion and typechecking in your IDE for this plugin's options:
 
 ```js
 import { swc, defineRollupSwcOption } from 'rollup-plugin-swc3';
@@ -77,7 +77,7 @@ export default {
 }
 ```
 
-If you want autocompletion in your IDE or type check:
+If you want autocompletion and typechecking in your IDE for this plugin's `minify` options:
 
 ```js
 import { minify, defineRollupSwcMinifyOption } from 'rollup-plugin-swc3'


### PR DESCRIPTION
The first two or three times I read the readme for this plugin, I thought the typechecking and intellisense being referred to was for _my_ code, and I was very confused (especially once I went and found the implementation and it turned out to be a pass-through). It finally occurred to me what was actually meant - typechecking and intellisense for the _plugin_ options, right?

Assuming so, I've updated the readme to make the target of the typechcking clearer.