### PR TITLE
docs: modify the vue jsx usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ You can either configure it in your `tsconfig.json` or in your `rollup.config.js
 
 ```js
 // Vue JSX
-import vueJsx from 'rollup-plugin-vue-jsx-compat'
+import vueJsx from '@vitejs/plugin-vue-jsx';
 import { swc, defineRollupSwcOption } from 'rollup-plugin-swc3';
 
 export default {
@@ -150,15 +150,7 @@ export default {
   output: {},
   plugins: [
     vueJsx(),
-    swc(defineRollupSwcOption({
-      jsc: {
-        transform: {
-          react: {
-              pragma: 'vueJsxCompat'
-          }
-        }
-      }
-    })),
+    swc(),
   ];
 }
 ```

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ You can either configure it in your `tsconfig.json` or in your `rollup.config.js
 ```js
 // Vue JSX
 import vueJsx from '@vitejs/plugin-vue-jsx';
-import { swc, defineRollupSwcOption } from 'rollup-plugin-swc3';
+import { swc } from 'rollup-plugin-swc3';
 
 export default {
   input: 'xxxx',


### PR DESCRIPTION
# Background

First [rollup-plugin-vue-jsx-compat](https://www.npmjs.com/package/rollup-plugin-vue-jsx-compat) isn't longger maintained. Currently, `rollup-plugin-vue` or others plugin from vue org repo is readonly now. And you can view the vite docs.It is recommended that you use the vite plugin. It's compatible with rollup.

cc @SukkaW .