### PR TITLE
refactor: replace `joycon` & `jsonc-parser` with `get-tsconfig`

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,12 @@ const swcPluginConfig = {}
 - `include` and `exclude` can be `String | RegExp | Array<String | RegExp>`, when supplied it will override default values.
 - `rollup-plugin-swc` will read your `tsconfig.json` or [`jsconfig.json`](https://code.visualstudio.com/docs/languages/jsconfig) for default values if your doesn't provide corresponding swc options:
   - The configuration your passed to `rollup-plugin-swc` will always have the highest priority (higher than `tsconfig.json`/`jsconfig.json`).
+  - `rollup-plugin-swc` will find the nearest `tsconfig.json`/`jsconfig.json` from the file that is currently being transpiled (just like `tsc`).
+    - With `tsconfig` option, you can also provide a custom filename (E.g. `tsconfig.rollup.json`, `jsconfig.compile.json`) for `rollup-plugin-swc` to find and resolve.
+    - You can also provide a full path (E.g. `/path/to/your/tsconfig.json`) to `tsconfig` option, and `rollup-plugin-swc` will only use the provided path as a single source of truth.
   - You can stop `rollup-plugin-swc` from reading `tsconfig.json`/`jsconfig.json` by setting `tsconfig` option to `false`.
-  - You can provide a custom `tsconfig.json`/`jsconfig.json` file by setting `tsconfig` option to a `string`.
   - `jsconfig.json` will be ignored if `tsconfig.json` and `jsconfig.json` both exist.
-  - The `extends` of `tsconfig.json`/`jsconfig.json` is not supported.
+  - The `extends` of `tsconfig.json`/`jsconfig.json` is ~~not supported~~ now supported.
   - `target` will be passed to swc's `jsc.target`.
   - `jsxImportSource`, `jsxFactory`, and `jsxFragmentFactory` will be passed to swc's `jsc.transform.react.importSource`, `jsc.transform.react.pragma` and `jsc.transform.react.pragmaFrag`.
   - When `jsx` is either `react-jsx` or `react-jsxdev`, swc's `jsc.transform.react.runtime` will be `automatic`, otherwise it will be `classic`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rollup-plugin-swc3",
-  "version": "0.5.0",
+  "version": "0.6.0-canary.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rollup-plugin-swc3",
-      "version": "0.5.0",
+      "version": "0.6.0-canary.0",
       "license": "MIT",
       "dependencies": {
         "@rollup/pluginutils": "^4.2.1",
@@ -16,7 +16,7 @@
       "devDependencies": {
         "@rollup/plugin-commonjs": "^22.0.2",
         "@rollup/plugin-json": "^4.1.0",
-        "@swc/core": "^1.2.249",
+        "@swc/core": "^1.3.0",
         "@types/chai": "^4.3.3",
         "@types/mocha": "^9.1.1",
         "@types/node": "^18.7.14",
@@ -337,9 +337,9 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.2.249",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.2.249.tgz",
-      "integrity": "sha512-aXAoNQLfba/3YcR6wdBM21Gp3q+G6Ay9Ey+BZHOBGW5amewzd84WYKIMoIc4fZhFj9dv6UaUu3B9qD+4oP/zhg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.0.tgz",
+      "integrity": "sha512-0mshAzMvdhL0v3lNMJowzMd8Du0bJf+PUTxhVm4uIb/h8qCDQjFERXj0RGejcDFSL7fJzLI3MzS5WR45KDrrLA==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -353,25 +353,25 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-android-arm-eabi": "1.2.249",
-        "@swc/core-android-arm64": "1.2.249",
-        "@swc/core-darwin-arm64": "1.2.249",
-        "@swc/core-darwin-x64": "1.2.249",
-        "@swc/core-freebsd-x64": "1.2.249",
-        "@swc/core-linux-arm-gnueabihf": "1.2.249",
-        "@swc/core-linux-arm64-gnu": "1.2.249",
-        "@swc/core-linux-arm64-musl": "1.2.249",
-        "@swc/core-linux-x64-gnu": "1.2.249",
-        "@swc/core-linux-x64-musl": "1.2.249",
-        "@swc/core-win32-arm64-msvc": "1.2.249",
-        "@swc/core-win32-ia32-msvc": "1.2.249",
-        "@swc/core-win32-x64-msvc": "1.2.249"
+        "@swc/core-android-arm-eabi": "1.3.0",
+        "@swc/core-android-arm64": "1.3.0",
+        "@swc/core-darwin-arm64": "1.3.0",
+        "@swc/core-darwin-x64": "1.3.0",
+        "@swc/core-freebsd-x64": "1.3.0",
+        "@swc/core-linux-arm-gnueabihf": "1.3.0",
+        "@swc/core-linux-arm64-gnu": "1.3.0",
+        "@swc/core-linux-arm64-musl": "1.3.0",
+        "@swc/core-linux-x64-gnu": "1.3.0",
+        "@swc/core-linux-x64-musl": "1.3.0",
+        "@swc/core-win32-arm64-msvc": "1.3.0",
+        "@swc/core-win32-ia32-msvc": "1.3.0",
+        "@swc/core-win32-x64-msvc": "1.3.0"
       }
     },
     "node_modules/@swc/core-android-arm-eabi": {
-      "version": "1.2.249",
-      "resolved": "https://registry.npmjs.org/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.2.249.tgz",
-      "integrity": "sha512-iOcGLHCsqZHQWGmgLEzagkRct40S3MjVBPQ/swR5kHUZef+//pjGyrr3RVyrp7bxb1Q0RaIKM8iZEvBiG6NGmw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.3.0.tgz",
+      "integrity": "sha512-1F/U0Vh78ZL7OUlCfaRWCtnYnIfsMA8WDtKyf3UT9b3C0L5HajB9TgMH4c0OKhjfP5Q2/M1/Pm00A+96nhKH8A==",
       "cpu": [
         "arm"
       ],
@@ -388,9 +388,9 @@
       }
     },
     "node_modules/@swc/core-android-arm64": {
-      "version": "1.2.249",
-      "resolved": "https://registry.npmjs.org/@swc/core-android-arm64/-/core-android-arm64-1.2.249.tgz",
-      "integrity": "sha512-SraLJ+Vaa8sP/V+gWFVQEKO4QzRVOu8/Df4JYzGj+qEAxsUjE4sIigCyDtYhOvv3hW4Rm8iABJ7me0obRhV6PA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-android-arm64/-/core-android-arm64-1.3.0.tgz",
+      "integrity": "sha512-dtryoOvQ27s9euAcLinExuaU+mMr8o0N8CBTH3f+JwKjQsIa9v0jPOjJ9jaWktnAdDy/FztB5iBCqTAwbqRG/w==",
       "cpu": [
         "arm64"
       ],
@@ -414,9 +414,9 @@
       "optional": true
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.2.249",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.2.249.tgz",
-      "integrity": "sha512-nlS9wX0tnq1DGv+I8h/KF3SuqZbn5B/+EDq3m88jE/X8RVNFTXkbO10nKQaXkPIEwOzUX3ImQoa070B/P4Gdhw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.0.tgz",
+      "integrity": "sha512-WSf29/wneQf5k7mdLKqaSRLDycIZaLATc6m7BKpFi34iCGSvXJfc375OrVG9BS0rReX5LT49XxXp6GQs9oFmVA==",
       "cpu": [
         "arm64"
       ],
@@ -430,9 +430,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.2.249",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.2.249.tgz",
-      "integrity": "sha512-myWcyqp541emXd+bLQ2G6fL7elpsO9D/r04ImvgPrNoESe2UhvkhXQ6T548nxg5qNprSzFRYQGOdD8ydaQSWKg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.0.tgz",
+      "integrity": "sha512-eDa1EZAnchMtkdZ52bWfseKla370c8BCj/RWAtHJcZMon3WVkWcZlMgZPPiPIxYz8hGtomqs+pkQv34hEVcx0A==",
       "cpu": [
         "x64"
       ],
@@ -446,9 +446,9 @@
       }
     },
     "node_modules/@swc/core-freebsd-x64": {
-      "version": "1.2.249",
-      "resolved": "https://registry.npmjs.org/@swc/core-freebsd-x64/-/core-freebsd-x64-1.2.249.tgz",
-      "integrity": "sha512-f2ahMbHGGAjGbDeKcsKed2oiW68hMJtBZaH0DUrg/VbDE9lkiIEdmU/Qpb1eDJjOtEpm1V47OTAeOpcJm3Fo3g==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-freebsd-x64/-/core-freebsd-x64-1.3.0.tgz",
+      "integrity": "sha512-ZV9rRmUZqJGCYqnV/3aIJUHELY/MFyABowDN8ijCvN67EjGfoNYx0jpd4hzFWwGC8LohthHNi6hiFfmnvGaKsw==",
       "cpu": [
         "x64"
       ],
@@ -472,9 +472,9 @@
       "optional": true
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.2.249",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.2.249.tgz",
-      "integrity": "sha512-RMcvTRSGhWBVRZbHT2wip4GSC8PiN9OtQqz0rcQw7uPfYKcaRKN/7b4HmJvuN1u6WDx+loq+GmnvN8ncLD3aXA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.0.tgz",
+      "integrity": "sha512-3fPWh4SB3lz0ZlQWsHjqZFJK1SIkYqjLpm6mR1jzp/LJx4Oq1baid9CP1eiLd/rijSIgVdUJNMGfiOK9uymEbw==",
       "cpu": [
         "arm"
       ],
@@ -498,9 +498,9 @@
       "optional": true
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.2.249",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.2.249.tgz",
-      "integrity": "sha512-EErpv+SZK5mqoKnhxw2VSW7QsGgeYVV7UL4XgfOxLUqDLXq8W/WDgsnhLsj+D8SSOIxFKRGnM6A3Au/XHwTV4w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.0.tgz",
+      "integrity": "sha512-CavXNYHKaPTMOvRXh1u7ZfMS5hKDXNSWTdeo+1+2M2XLCP0r0+2Iaeg0IZJD8nIwAlwwP8+rskan2Ekq6jaIfw==",
       "cpu": [
         "arm64"
       ],
@@ -514,9 +514,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.2.249",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.2.249.tgz",
-      "integrity": "sha512-5ig/Aju0yP9ljBeqCGsxBCAZRVBNPVFUroxv51hAWk5ji0CIROctfWH4NkpsJqC9AyGxZPw3Q/cqzUe5o0Gc5A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.0.tgz",
+      "integrity": "sha512-/3UiX8jH+OWleJbqYiwJEf4GQKP6xnm/6gyBt7V0GdhM4/ETMvzTFUNRObgpmxYMhXmNGAlxekU8+0QuAvyRJQ==",
       "cpu": [
         "arm64"
       ],
@@ -530,9 +530,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.2.249",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.2.249.tgz",
-      "integrity": "sha512-lE9uzEXj0f4Qw53yHTf5j0hH2WgwbQstTamaUBFHGXGAUlqhSMJW9Yc1pvejbDD1VAADCeqc1eSNH3aihMRP4A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.0.tgz",
+      "integrity": "sha512-Ds76Lu7vfE01rgFcf9O1OuNBwQSHBpGwGOKGnwob6T2SCR4DBQz4MD0jLw/tdCZGR8x7NVMteBzQAp3CsUORZw==",
       "cpu": [
         "x64"
       ],
@@ -546,9 +546,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.2.249",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.2.249.tgz",
-      "integrity": "sha512-2hiUkpRgGXEJz2+SoaZIRUuPWeBKj3PH28fN0WR9HIqbglU8gKr3LHyQKbx8SRBosYeSbRSFknw44ucK7IY9rQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.0.tgz",
+      "integrity": "sha512-fgGq/SyX6DsTgJIujBbopaEu17f8u+cyTsJBluc5cF7HxspB4wC72sdq4KGgUoEYObVTgFejnEBZkm8hLOCwYA==",
       "cpu": [
         "x64"
       ],
@@ -562,9 +562,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.2.249",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.2.249.tgz",
-      "integrity": "sha512-lP8Gvqnj6FSnJpNkR06yd522CUS3HbS7D1ZWhxlr7xy2xB9bmQhQL3CloZONVRBU+0vvwE54p4k5X6/oJus+qQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.0.tgz",
+      "integrity": "sha512-7B7XggbCmm1oHeNvz5ekWmWmJP/WeGpmGZ10Qca3/zrVm+IRN4ZBT+jpWm+cuuYJh0Llr5UYgTFib3cyOLWkJg==",
       "cpu": [
         "arm64"
       ],
@@ -588,9 +588,9 @@
       "optional": true
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.2.249",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.2.249.tgz",
-      "integrity": "sha512-zm4Wj1cvmiBHShRhX33hSzI/I7FctWA6svxlsx1zEQmTtKSqUqEKoswy/XUNsJ9p6Knf9INLPItfv/7HI/Eqaw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.0.tgz",
+      "integrity": "sha512-vDIu5FjoqB3G7awWCyNsUh5UAzTtJPMEwG75Cwx51fxMPxXrVPHP6XpRovIjQ5wiKL5lGqicckieduJkgBvp7Q==",
       "cpu": [
         "ia32"
       ],
@@ -614,9 +614,9 @@
       "optional": true
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.2.249",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.2.249.tgz",
-      "integrity": "sha512-IxRvePerNYVJXr6lk0P09y1XAqPncMHWWvWm7p3CvTAfxEuiM5DqD5wtIbFMXfPSi1TTSkzAqBoH6Nushvgb3Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.0.tgz",
+      "integrity": "sha512-ZEgMvq01Ningz6IOD6ixrpsfA83u+B/1TwnYmWuRl9hMml9lnPwdg3o1P0pwbSO1moKlUhSwc8WVYmI0bXF+gA==",
       "cpu": [
         "x64"
       ],
@@ -4462,30 +4462,30 @@
       }
     },
     "@swc/core": {
-      "version": "1.2.249",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.2.249.tgz",
-      "integrity": "sha512-aXAoNQLfba/3YcR6wdBM21Gp3q+G6Ay9Ey+BZHOBGW5amewzd84WYKIMoIc4fZhFj9dv6UaUu3B9qD+4oP/zhg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.0.tgz",
+      "integrity": "sha512-0mshAzMvdhL0v3lNMJowzMd8Du0bJf+PUTxhVm4uIb/h8qCDQjFERXj0RGejcDFSL7fJzLI3MzS5WR45KDrrLA==",
       "dev": true,
       "requires": {
-        "@swc/core-android-arm-eabi": "1.2.249",
-        "@swc/core-android-arm64": "1.2.249",
-        "@swc/core-darwin-arm64": "1.2.249",
-        "@swc/core-darwin-x64": "1.2.249",
-        "@swc/core-freebsd-x64": "1.2.249",
-        "@swc/core-linux-arm-gnueabihf": "1.2.249",
-        "@swc/core-linux-arm64-gnu": "1.2.249",
-        "@swc/core-linux-arm64-musl": "1.2.249",
-        "@swc/core-linux-x64-gnu": "1.2.249",
-        "@swc/core-linux-x64-musl": "1.2.249",
-        "@swc/core-win32-arm64-msvc": "1.2.249",
-        "@swc/core-win32-ia32-msvc": "1.2.249",
-        "@swc/core-win32-x64-msvc": "1.2.249"
+        "@swc/core-android-arm-eabi": "1.3.0",
+        "@swc/core-android-arm64": "1.3.0",
+        "@swc/core-darwin-arm64": "1.3.0",
+        "@swc/core-darwin-x64": "1.3.0",
+        "@swc/core-freebsd-x64": "1.3.0",
+        "@swc/core-linux-arm-gnueabihf": "1.3.0",
+        "@swc/core-linux-arm64-gnu": "1.3.0",
+        "@swc/core-linux-arm64-musl": "1.3.0",
+        "@swc/core-linux-x64-gnu": "1.3.0",
+        "@swc/core-linux-x64-musl": "1.3.0",
+        "@swc/core-win32-arm64-msvc": "1.3.0",
+        "@swc/core-win32-ia32-msvc": "1.3.0",
+        "@swc/core-win32-x64-msvc": "1.3.0"
       }
     },
     "@swc/core-android-arm-eabi": {
-      "version": "1.2.249",
-      "resolved": "https://registry.npmjs.org/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.2.249.tgz",
-      "integrity": "sha512-iOcGLHCsqZHQWGmgLEzagkRct40S3MjVBPQ/swR5kHUZef+//pjGyrr3RVyrp7bxb1Q0RaIKM8iZEvBiG6NGmw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.3.0.tgz",
+      "integrity": "sha512-1F/U0Vh78ZL7OUlCfaRWCtnYnIfsMA8WDtKyf3UT9b3C0L5HajB9TgMH4c0OKhjfP5Q2/M1/Pm00A+96nhKH8A==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -4493,9 +4493,9 @@
       }
     },
     "@swc/core-android-arm64": {
-      "version": "1.2.249",
-      "resolved": "https://registry.npmjs.org/@swc/core-android-arm64/-/core-android-arm64-1.2.249.tgz",
-      "integrity": "sha512-SraLJ+Vaa8sP/V+gWFVQEKO4QzRVOu8/Df4JYzGj+qEAxsUjE4sIigCyDtYhOvv3hW4Rm8iABJ7me0obRhV6PA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-android-arm64/-/core-android-arm64-1.3.0.tgz",
+      "integrity": "sha512-dtryoOvQ27s9euAcLinExuaU+mMr8o0N8CBTH3f+JwKjQsIa9v0jPOjJ9jaWktnAdDy/FztB5iBCqTAwbqRG/w==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -4512,23 +4512,23 @@
       }
     },
     "@swc/core-darwin-arm64": {
-      "version": "1.2.249",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.2.249.tgz",
-      "integrity": "sha512-nlS9wX0tnq1DGv+I8h/KF3SuqZbn5B/+EDq3m88jE/X8RVNFTXkbO10nKQaXkPIEwOzUX3ImQoa070B/P4Gdhw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.0.tgz",
+      "integrity": "sha512-WSf29/wneQf5k7mdLKqaSRLDycIZaLATc6m7BKpFi34iCGSvXJfc375OrVG9BS0rReX5LT49XxXp6GQs9oFmVA==",
       "dev": true,
       "optional": true
     },
     "@swc/core-darwin-x64": {
-      "version": "1.2.249",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.2.249.tgz",
-      "integrity": "sha512-myWcyqp541emXd+bLQ2G6fL7elpsO9D/r04ImvgPrNoESe2UhvkhXQ6T548nxg5qNprSzFRYQGOdD8ydaQSWKg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.0.tgz",
+      "integrity": "sha512-eDa1EZAnchMtkdZ52bWfseKla370c8BCj/RWAtHJcZMon3WVkWcZlMgZPPiPIxYz8hGtomqs+pkQv34hEVcx0A==",
       "dev": true,
       "optional": true
     },
     "@swc/core-freebsd-x64": {
-      "version": "1.2.249",
-      "resolved": "https://registry.npmjs.org/@swc/core-freebsd-x64/-/core-freebsd-x64-1.2.249.tgz",
-      "integrity": "sha512-f2ahMbHGGAjGbDeKcsKed2oiW68hMJtBZaH0DUrg/VbDE9lkiIEdmU/Qpb1eDJjOtEpm1V47OTAeOpcJm3Fo3g==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-freebsd-x64/-/core-freebsd-x64-1.3.0.tgz",
+      "integrity": "sha512-ZV9rRmUZqJGCYqnV/3aIJUHELY/MFyABowDN8ijCvN67EjGfoNYx0jpd4hzFWwGC8LohthHNi6hiFfmnvGaKsw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -4545,9 +4545,9 @@
       }
     },
     "@swc/core-linux-arm-gnueabihf": {
-      "version": "1.2.249",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.2.249.tgz",
-      "integrity": "sha512-RMcvTRSGhWBVRZbHT2wip4GSC8PiN9OtQqz0rcQw7uPfYKcaRKN/7b4HmJvuN1u6WDx+loq+GmnvN8ncLD3aXA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.0.tgz",
+      "integrity": "sha512-3fPWh4SB3lz0ZlQWsHjqZFJK1SIkYqjLpm6mR1jzp/LJx4Oq1baid9CP1eiLd/rijSIgVdUJNMGfiOK9uymEbw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -4564,37 +4564,37 @@
       }
     },
     "@swc/core-linux-arm64-gnu": {
-      "version": "1.2.249",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.2.249.tgz",
-      "integrity": "sha512-EErpv+SZK5mqoKnhxw2VSW7QsGgeYVV7UL4XgfOxLUqDLXq8W/WDgsnhLsj+D8SSOIxFKRGnM6A3Au/XHwTV4w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.0.tgz",
+      "integrity": "sha512-CavXNYHKaPTMOvRXh1u7ZfMS5hKDXNSWTdeo+1+2M2XLCP0r0+2Iaeg0IZJD8nIwAlwwP8+rskan2Ekq6jaIfw==",
       "dev": true,
       "optional": true
     },
     "@swc/core-linux-arm64-musl": {
-      "version": "1.2.249",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.2.249.tgz",
-      "integrity": "sha512-5ig/Aju0yP9ljBeqCGsxBCAZRVBNPVFUroxv51hAWk5ji0CIROctfWH4NkpsJqC9AyGxZPw3Q/cqzUe5o0Gc5A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.0.tgz",
+      "integrity": "sha512-/3UiX8jH+OWleJbqYiwJEf4GQKP6xnm/6gyBt7V0GdhM4/ETMvzTFUNRObgpmxYMhXmNGAlxekU8+0QuAvyRJQ==",
       "dev": true,
       "optional": true
     },
     "@swc/core-linux-x64-gnu": {
-      "version": "1.2.249",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.2.249.tgz",
-      "integrity": "sha512-lE9uzEXj0f4Qw53yHTf5j0hH2WgwbQstTamaUBFHGXGAUlqhSMJW9Yc1pvejbDD1VAADCeqc1eSNH3aihMRP4A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.0.tgz",
+      "integrity": "sha512-Ds76Lu7vfE01rgFcf9O1OuNBwQSHBpGwGOKGnwob6T2SCR4DBQz4MD0jLw/tdCZGR8x7NVMteBzQAp3CsUORZw==",
       "dev": true,
       "optional": true
     },
     "@swc/core-linux-x64-musl": {
-      "version": "1.2.249",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.2.249.tgz",
-      "integrity": "sha512-2hiUkpRgGXEJz2+SoaZIRUuPWeBKj3PH28fN0WR9HIqbglU8gKr3LHyQKbx8SRBosYeSbRSFknw44ucK7IY9rQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.0.tgz",
+      "integrity": "sha512-fgGq/SyX6DsTgJIujBbopaEu17f8u+cyTsJBluc5cF7HxspB4wC72sdq4KGgUoEYObVTgFejnEBZkm8hLOCwYA==",
       "dev": true,
       "optional": true
     },
     "@swc/core-win32-arm64-msvc": {
-      "version": "1.2.249",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.2.249.tgz",
-      "integrity": "sha512-lP8Gvqnj6FSnJpNkR06yd522CUS3HbS7D1ZWhxlr7xy2xB9bmQhQL3CloZONVRBU+0vvwE54p4k5X6/oJus+qQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.0.tgz",
+      "integrity": "sha512-7B7XggbCmm1oHeNvz5ekWmWmJP/WeGpmGZ10Qca3/zrVm+IRN4ZBT+jpWm+cuuYJh0Llr5UYgTFib3cyOLWkJg==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -4611,9 +4611,9 @@
       }
     },
     "@swc/core-win32-ia32-msvc": {
-      "version": "1.2.249",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.2.249.tgz",
-      "integrity": "sha512-zm4Wj1cvmiBHShRhX33hSzI/I7FctWA6svxlsx1zEQmTtKSqUqEKoswy/XUNsJ9p6Knf9INLPItfv/7HI/Eqaw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.0.tgz",
+      "integrity": "sha512-vDIu5FjoqB3G7awWCyNsUh5UAzTtJPMEwG75Cwx51fxMPxXrVPHP6XpRovIjQ5wiKL5lGqicckieduJkgBvp7Q==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -4630,9 +4630,9 @@
       }
     },
     "@swc/core-win32-x64-msvc": {
-      "version": "1.2.249",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.2.249.tgz",
-      "integrity": "sha512-IxRvePerNYVJXr6lk0P09y1XAqPncMHWWvWm7p3CvTAfxEuiM5DqD5wtIbFMXfPSi1TTSkzAqBoH6Nushvgb3Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.0.tgz",
+      "integrity": "sha512-ZEgMvq01Ningz6IOD6ixrpsfA83u+B/1TwnYmWuRl9hMml9lnPwdg3o1P0pwbSO1moKlUhSwc8WVYmI0bXF+gA==",
       "dev": true,
       "optional": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,22 @@
 {
   "name": "rollup-plugin-swc3",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rollup-plugin-swc3",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@rollup/pluginutils": "^4.2.1",
         "deepmerge": "^4.2.2",
-        "joycon": "^3.1.1",
-        "jsonc-parser": "^3.2.0"
+        "get-tsconfig": "^4.2.0"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^22.0.2",
         "@rollup/plugin-json": "^4.1.0",
-        "@swc/core": "^1.2.246",
+        "@swc/core": "^1.2.249",
         "@types/chai": "^4.3.3",
         "@types/mocha": "^9.1.1",
         "@types/node": "^18.7.14",
@@ -338,9 +337,9 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.2.246",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.2.246.tgz",
-      "integrity": "sha512-wi0IZLv5GC2zjZoiEDoLZraS7/ZV2Y6vnAII//Ulobvdc4zuQoceJvYvyO3IJMB0bZVoiY/fn0Ae/iEMx9PFBQ==",
+      "version": "1.2.249",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.2.249.tgz",
+      "integrity": "sha512-aXAoNQLfba/3YcR6wdBM21Gp3q+G6Ay9Ey+BZHOBGW5amewzd84WYKIMoIc4fZhFj9dv6UaUu3B9qD+4oP/zhg==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -354,25 +353,25 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-android-arm-eabi": "1.2.246",
-        "@swc/core-android-arm64": "1.2.246",
-        "@swc/core-darwin-arm64": "1.2.246",
-        "@swc/core-darwin-x64": "1.2.246",
-        "@swc/core-freebsd-x64": "1.2.246",
-        "@swc/core-linux-arm-gnueabihf": "1.2.246",
-        "@swc/core-linux-arm64-gnu": "1.2.246",
-        "@swc/core-linux-arm64-musl": "1.2.246",
-        "@swc/core-linux-x64-gnu": "1.2.246",
-        "@swc/core-linux-x64-musl": "1.2.246",
-        "@swc/core-win32-arm64-msvc": "1.2.246",
-        "@swc/core-win32-ia32-msvc": "1.2.246",
-        "@swc/core-win32-x64-msvc": "1.2.246"
+        "@swc/core-android-arm-eabi": "1.2.249",
+        "@swc/core-android-arm64": "1.2.249",
+        "@swc/core-darwin-arm64": "1.2.249",
+        "@swc/core-darwin-x64": "1.2.249",
+        "@swc/core-freebsd-x64": "1.2.249",
+        "@swc/core-linux-arm-gnueabihf": "1.2.249",
+        "@swc/core-linux-arm64-gnu": "1.2.249",
+        "@swc/core-linux-arm64-musl": "1.2.249",
+        "@swc/core-linux-x64-gnu": "1.2.249",
+        "@swc/core-linux-x64-musl": "1.2.249",
+        "@swc/core-win32-arm64-msvc": "1.2.249",
+        "@swc/core-win32-ia32-msvc": "1.2.249",
+        "@swc/core-win32-x64-msvc": "1.2.249"
       }
     },
     "node_modules/@swc/core-android-arm-eabi": {
-      "version": "1.2.246",
-      "resolved": "https://registry.npmjs.org/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.2.246.tgz",
-      "integrity": "sha512-3LXgOhtZnDsBacv71WRhuiuzjD0Q7m3XLzGyndtNZ+os4SOlmFiOTjZ3iMhnafKWZslmgAFrMemLPDOH+Np8OQ==",
+      "version": "1.2.249",
+      "resolved": "https://registry.npmjs.org/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.2.249.tgz",
+      "integrity": "sha512-iOcGLHCsqZHQWGmgLEzagkRct40S3MjVBPQ/swR5kHUZef+//pjGyrr3RVyrp7bxb1Q0RaIKM8iZEvBiG6NGmw==",
       "cpu": [
         "arm"
       ],
@@ -389,9 +388,9 @@
       }
     },
     "node_modules/@swc/core-android-arm64": {
-      "version": "1.2.246",
-      "resolved": "https://registry.npmjs.org/@swc/core-android-arm64/-/core-android-arm64-1.2.246.tgz",
-      "integrity": "sha512-m/BCkI7Wo4nMN6PLM1EnO43p7aoi9sxY3KESVCyAEZ07QlY++a0GEgVqCkKHWZ8zcfbLsesDA2E9/DYMOgPzxg==",
+      "version": "1.2.249",
+      "resolved": "https://registry.npmjs.org/@swc/core-android-arm64/-/core-android-arm64-1.2.249.tgz",
+      "integrity": "sha512-SraLJ+Vaa8sP/V+gWFVQEKO4QzRVOu8/Df4JYzGj+qEAxsUjE4sIigCyDtYhOvv3hW4Rm8iABJ7me0obRhV6PA==",
       "cpu": [
         "arm64"
       ],
@@ -415,9 +414,9 @@
       "optional": true
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.2.246",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.2.246.tgz",
-      "integrity": "sha512-w3RbXiGPE1LshUS5T3McBJAxl9gCFZanaY5ALuUNERAIdjVxjGmB815O0hPDmjlJrhvwhKI9+Rx4X/M1vlZDtA==",
+      "version": "1.2.249",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.2.249.tgz",
+      "integrity": "sha512-nlS9wX0tnq1DGv+I8h/KF3SuqZbn5B/+EDq3m88jE/X8RVNFTXkbO10nKQaXkPIEwOzUX3ImQoa070B/P4Gdhw==",
       "cpu": [
         "arm64"
       ],
@@ -431,9 +430,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.2.246",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.2.246.tgz",
-      "integrity": "sha512-2odv/ZlV9VsQuQDIul1jU2+u5vPCw6Xyg0BaejaA5FCcnXi6w2xf6/ryFFgQy4i+LP3oZdOtJG1dZiA8ozplKw==",
+      "version": "1.2.249",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.2.249.tgz",
+      "integrity": "sha512-myWcyqp541emXd+bLQ2G6fL7elpsO9D/r04ImvgPrNoESe2UhvkhXQ6T548nxg5qNprSzFRYQGOdD8ydaQSWKg==",
       "cpu": [
         "x64"
       ],
@@ -447,9 +446,9 @@
       }
     },
     "node_modules/@swc/core-freebsd-x64": {
-      "version": "1.2.246",
-      "resolved": "https://registry.npmjs.org/@swc/core-freebsd-x64/-/core-freebsd-x64-1.2.246.tgz",
-      "integrity": "sha512-GvQuHKTc8TyJ3jn1e4HZasgGfBvD3nGe55syzAAaedh8tuU7VnQjxl1Dtq5DtyCBDDbulzuHcwLFQnWNWgEMyA==",
+      "version": "1.2.249",
+      "resolved": "https://registry.npmjs.org/@swc/core-freebsd-x64/-/core-freebsd-x64-1.2.249.tgz",
+      "integrity": "sha512-f2ahMbHGGAjGbDeKcsKed2oiW68hMJtBZaH0DUrg/VbDE9lkiIEdmU/Qpb1eDJjOtEpm1V47OTAeOpcJm3Fo3g==",
       "cpu": [
         "x64"
       ],
@@ -473,9 +472,9 @@
       "optional": true
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.2.246",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.2.246.tgz",
-      "integrity": "sha512-J1g/q9S9I0uLn/erHoIEpYvzr48oTiVY2cmniw/q0jRfg+ECTI24AjWQj5sdIoB+GLqEn5+GNhUbYIVoCTubRA==",
+      "version": "1.2.249",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.2.249.tgz",
+      "integrity": "sha512-RMcvTRSGhWBVRZbHT2wip4GSC8PiN9OtQqz0rcQw7uPfYKcaRKN/7b4HmJvuN1u6WDx+loq+GmnvN8ncLD3aXA==",
       "cpu": [
         "arm"
       ],
@@ -499,9 +498,9 @@
       "optional": true
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.2.246",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.2.246.tgz",
-      "integrity": "sha512-J7B6XgOiNgCyZp5WXkC0wi2ov3SpS5z3o6++n0qz8d1UqswDaOjnpGQgPITXFkKFFrs/uWdPiNbbBsMum6C5gQ==",
+      "version": "1.2.249",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.2.249.tgz",
+      "integrity": "sha512-EErpv+SZK5mqoKnhxw2VSW7QsGgeYVV7UL4XgfOxLUqDLXq8W/WDgsnhLsj+D8SSOIxFKRGnM6A3Au/XHwTV4w==",
       "cpu": [
         "arm64"
       ],
@@ -515,9 +514,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.2.246",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.2.246.tgz",
-      "integrity": "sha512-AFv/95BgZkdrLa5YfvP/69v8qT+zq0pRVZxv/IUW1mmM1UGVKrcU0i0y/haYivIFcLX+Ox5IYmIibO9C9P9pOA==",
+      "version": "1.2.249",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.2.249.tgz",
+      "integrity": "sha512-5ig/Aju0yP9ljBeqCGsxBCAZRVBNPVFUroxv51hAWk5ji0CIROctfWH4NkpsJqC9AyGxZPw3Q/cqzUe5o0Gc5A==",
       "cpu": [
         "arm64"
       ],
@@ -531,9 +530,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.2.246",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.2.246.tgz",
-      "integrity": "sha512-egM6QX7PaLB2cQXJidfQvwT9OzUkTl1XIUVz+IOpv4om0xxtyJQjy/2ENjjtiw7C9IuV1xASOLlE1tMfLY7osw==",
+      "version": "1.2.249",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.2.249.tgz",
+      "integrity": "sha512-lE9uzEXj0f4Qw53yHTf5j0hH2WgwbQstTamaUBFHGXGAUlqhSMJW9Yc1pvejbDD1VAADCeqc1eSNH3aihMRP4A==",
       "cpu": [
         "x64"
       ],
@@ -547,9 +546,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.2.246",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.2.246.tgz",
-      "integrity": "sha512-SKJRqgcbiZ4h2O0p+JA/NsmmV1ZwHTxdMRKkiNSvkyybGyOwPgP01CVITggVohz0j9NGwgIVAJOcn4Hx5WCcuw==",
+      "version": "1.2.249",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.2.249.tgz",
+      "integrity": "sha512-2hiUkpRgGXEJz2+SoaZIRUuPWeBKj3PH28fN0WR9HIqbglU8gKr3LHyQKbx8SRBosYeSbRSFknw44ucK7IY9rQ==",
       "cpu": [
         "x64"
       ],
@@ -563,9 +562,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.2.246",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.2.246.tgz",
-      "integrity": "sha512-VISXunc1sU0jm5dC37TLXYTdmIcz4b9ItfrGpc+hIZWDwGbagSwHiThnJL3OlpZQrcrbZ0w+/zg4EYb5JenbXg==",
+      "version": "1.2.249",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.2.249.tgz",
+      "integrity": "sha512-lP8Gvqnj6FSnJpNkR06yd522CUS3HbS7D1ZWhxlr7xy2xB9bmQhQL3CloZONVRBU+0vvwE54p4k5X6/oJus+qQ==",
       "cpu": [
         "arm64"
       ],
@@ -589,9 +588,9 @@
       "optional": true
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.2.246",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.2.246.tgz",
-      "integrity": "sha512-4tp3BrFur90PB2EM5vvfsw2zyBDFhC1PRAYGXJf9oF0Fnf4kQt+cBYXGy13I/kJfhd/cKQJC8o9lBV+dtLtGDg==",
+      "version": "1.2.249",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.2.249.tgz",
+      "integrity": "sha512-zm4Wj1cvmiBHShRhX33hSzI/I7FctWA6svxlsx1zEQmTtKSqUqEKoswy/XUNsJ9p6Knf9INLPItfv/7HI/Eqaw==",
       "cpu": [
         "ia32"
       ],
@@ -615,9 +614,9 @@
       "optional": true
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.2.246",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.2.246.tgz",
-      "integrity": "sha512-wD22xEFdiYtpq7Nwq1k8Dqwe08zrgaEhO9rn7G9DUtjHPSeIOpNQ1dQrzGBVK5Ah/3WJuciCAyUbVtaDUROhEQ==",
+      "version": "1.2.249",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.2.249.tgz",
+      "integrity": "sha512-IxRvePerNYVJXr6lk0P09y1XAqPncMHWWvWm7p3CvTAfxEuiM5DqD5wtIbFMXfPSi1TTSkzAqBoH6Nushvgb3Q==",
       "cpu": [
         "x64"
       ],
@@ -2222,7 +2221,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.2.0.tgz",
       "integrity": "sha512-X8u8fREiYOE6S8hLbq99PeykTDoLVnxvF4DjWKJmz9xy2nNRdUcV8ZN9tniJFeKyTU3qnC9lL8n4Chd6LmVKHg==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
@@ -2730,14 +2728,6 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-    "node_modules/joycon": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
-      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -2780,11 +2770,6 @@
       "bin": {
         "json5": "lib/cli.js"
       }
-    },
-    "node_modules/jsonc-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -4477,30 +4462,30 @@
       }
     },
     "@swc/core": {
-      "version": "1.2.246",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.2.246.tgz",
-      "integrity": "sha512-wi0IZLv5GC2zjZoiEDoLZraS7/ZV2Y6vnAII//Ulobvdc4zuQoceJvYvyO3IJMB0bZVoiY/fn0Ae/iEMx9PFBQ==",
+      "version": "1.2.249",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.2.249.tgz",
+      "integrity": "sha512-aXAoNQLfba/3YcR6wdBM21Gp3q+G6Ay9Ey+BZHOBGW5amewzd84WYKIMoIc4fZhFj9dv6UaUu3B9qD+4oP/zhg==",
       "dev": true,
       "requires": {
-        "@swc/core-android-arm-eabi": "1.2.246",
-        "@swc/core-android-arm64": "1.2.246",
-        "@swc/core-darwin-arm64": "1.2.246",
-        "@swc/core-darwin-x64": "1.2.246",
-        "@swc/core-freebsd-x64": "1.2.246",
-        "@swc/core-linux-arm-gnueabihf": "1.2.246",
-        "@swc/core-linux-arm64-gnu": "1.2.246",
-        "@swc/core-linux-arm64-musl": "1.2.246",
-        "@swc/core-linux-x64-gnu": "1.2.246",
-        "@swc/core-linux-x64-musl": "1.2.246",
-        "@swc/core-win32-arm64-msvc": "1.2.246",
-        "@swc/core-win32-ia32-msvc": "1.2.246",
-        "@swc/core-win32-x64-msvc": "1.2.246"
+        "@swc/core-android-arm-eabi": "1.2.249",
+        "@swc/core-android-arm64": "1.2.249",
+        "@swc/core-darwin-arm64": "1.2.249",
+        "@swc/core-darwin-x64": "1.2.249",
+        "@swc/core-freebsd-x64": "1.2.249",
+        "@swc/core-linux-arm-gnueabihf": "1.2.249",
+        "@swc/core-linux-arm64-gnu": "1.2.249",
+        "@swc/core-linux-arm64-musl": "1.2.249",
+        "@swc/core-linux-x64-gnu": "1.2.249",
+        "@swc/core-linux-x64-musl": "1.2.249",
+        "@swc/core-win32-arm64-msvc": "1.2.249",
+        "@swc/core-win32-ia32-msvc": "1.2.249",
+        "@swc/core-win32-x64-msvc": "1.2.249"
       }
     },
     "@swc/core-android-arm-eabi": {
-      "version": "1.2.246",
-      "resolved": "https://registry.npmjs.org/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.2.246.tgz",
-      "integrity": "sha512-3LXgOhtZnDsBacv71WRhuiuzjD0Q7m3XLzGyndtNZ+os4SOlmFiOTjZ3iMhnafKWZslmgAFrMemLPDOH+Np8OQ==",
+      "version": "1.2.249",
+      "resolved": "https://registry.npmjs.org/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.2.249.tgz",
+      "integrity": "sha512-iOcGLHCsqZHQWGmgLEzagkRct40S3MjVBPQ/swR5kHUZef+//pjGyrr3RVyrp7bxb1Q0RaIKM8iZEvBiG6NGmw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -4508,9 +4493,9 @@
       }
     },
     "@swc/core-android-arm64": {
-      "version": "1.2.246",
-      "resolved": "https://registry.npmjs.org/@swc/core-android-arm64/-/core-android-arm64-1.2.246.tgz",
-      "integrity": "sha512-m/BCkI7Wo4nMN6PLM1EnO43p7aoi9sxY3KESVCyAEZ07QlY++a0GEgVqCkKHWZ8zcfbLsesDA2E9/DYMOgPzxg==",
+      "version": "1.2.249",
+      "resolved": "https://registry.npmjs.org/@swc/core-android-arm64/-/core-android-arm64-1.2.249.tgz",
+      "integrity": "sha512-SraLJ+Vaa8sP/V+gWFVQEKO4QzRVOu8/Df4JYzGj+qEAxsUjE4sIigCyDtYhOvv3hW4Rm8iABJ7me0obRhV6PA==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -4527,23 +4512,23 @@
       }
     },
     "@swc/core-darwin-arm64": {
-      "version": "1.2.246",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.2.246.tgz",
-      "integrity": "sha512-w3RbXiGPE1LshUS5T3McBJAxl9gCFZanaY5ALuUNERAIdjVxjGmB815O0hPDmjlJrhvwhKI9+Rx4X/M1vlZDtA==",
+      "version": "1.2.249",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.2.249.tgz",
+      "integrity": "sha512-nlS9wX0tnq1DGv+I8h/KF3SuqZbn5B/+EDq3m88jE/X8RVNFTXkbO10nKQaXkPIEwOzUX3ImQoa070B/P4Gdhw==",
       "dev": true,
       "optional": true
     },
     "@swc/core-darwin-x64": {
-      "version": "1.2.246",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.2.246.tgz",
-      "integrity": "sha512-2odv/ZlV9VsQuQDIul1jU2+u5vPCw6Xyg0BaejaA5FCcnXi6w2xf6/ryFFgQy4i+LP3oZdOtJG1dZiA8ozplKw==",
+      "version": "1.2.249",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.2.249.tgz",
+      "integrity": "sha512-myWcyqp541emXd+bLQ2G6fL7elpsO9D/r04ImvgPrNoESe2UhvkhXQ6T548nxg5qNprSzFRYQGOdD8ydaQSWKg==",
       "dev": true,
       "optional": true
     },
     "@swc/core-freebsd-x64": {
-      "version": "1.2.246",
-      "resolved": "https://registry.npmjs.org/@swc/core-freebsd-x64/-/core-freebsd-x64-1.2.246.tgz",
-      "integrity": "sha512-GvQuHKTc8TyJ3jn1e4HZasgGfBvD3nGe55syzAAaedh8tuU7VnQjxl1Dtq5DtyCBDDbulzuHcwLFQnWNWgEMyA==",
+      "version": "1.2.249",
+      "resolved": "https://registry.npmjs.org/@swc/core-freebsd-x64/-/core-freebsd-x64-1.2.249.tgz",
+      "integrity": "sha512-f2ahMbHGGAjGbDeKcsKed2oiW68hMJtBZaH0DUrg/VbDE9lkiIEdmU/Qpb1eDJjOtEpm1V47OTAeOpcJm3Fo3g==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -4560,9 +4545,9 @@
       }
     },
     "@swc/core-linux-arm-gnueabihf": {
-      "version": "1.2.246",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.2.246.tgz",
-      "integrity": "sha512-J1g/q9S9I0uLn/erHoIEpYvzr48oTiVY2cmniw/q0jRfg+ECTI24AjWQj5sdIoB+GLqEn5+GNhUbYIVoCTubRA==",
+      "version": "1.2.249",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.2.249.tgz",
+      "integrity": "sha512-RMcvTRSGhWBVRZbHT2wip4GSC8PiN9OtQqz0rcQw7uPfYKcaRKN/7b4HmJvuN1u6WDx+loq+GmnvN8ncLD3aXA==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -4579,37 +4564,37 @@
       }
     },
     "@swc/core-linux-arm64-gnu": {
-      "version": "1.2.246",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.2.246.tgz",
-      "integrity": "sha512-J7B6XgOiNgCyZp5WXkC0wi2ov3SpS5z3o6++n0qz8d1UqswDaOjnpGQgPITXFkKFFrs/uWdPiNbbBsMum6C5gQ==",
+      "version": "1.2.249",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.2.249.tgz",
+      "integrity": "sha512-EErpv+SZK5mqoKnhxw2VSW7QsGgeYVV7UL4XgfOxLUqDLXq8W/WDgsnhLsj+D8SSOIxFKRGnM6A3Au/XHwTV4w==",
       "dev": true,
       "optional": true
     },
     "@swc/core-linux-arm64-musl": {
-      "version": "1.2.246",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.2.246.tgz",
-      "integrity": "sha512-AFv/95BgZkdrLa5YfvP/69v8qT+zq0pRVZxv/IUW1mmM1UGVKrcU0i0y/haYivIFcLX+Ox5IYmIibO9C9P9pOA==",
+      "version": "1.2.249",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.2.249.tgz",
+      "integrity": "sha512-5ig/Aju0yP9ljBeqCGsxBCAZRVBNPVFUroxv51hAWk5ji0CIROctfWH4NkpsJqC9AyGxZPw3Q/cqzUe5o0Gc5A==",
       "dev": true,
       "optional": true
     },
     "@swc/core-linux-x64-gnu": {
-      "version": "1.2.246",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.2.246.tgz",
-      "integrity": "sha512-egM6QX7PaLB2cQXJidfQvwT9OzUkTl1XIUVz+IOpv4om0xxtyJQjy/2ENjjtiw7C9IuV1xASOLlE1tMfLY7osw==",
+      "version": "1.2.249",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.2.249.tgz",
+      "integrity": "sha512-lE9uzEXj0f4Qw53yHTf5j0hH2WgwbQstTamaUBFHGXGAUlqhSMJW9Yc1pvejbDD1VAADCeqc1eSNH3aihMRP4A==",
       "dev": true,
       "optional": true
     },
     "@swc/core-linux-x64-musl": {
-      "version": "1.2.246",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.2.246.tgz",
-      "integrity": "sha512-SKJRqgcbiZ4h2O0p+JA/NsmmV1ZwHTxdMRKkiNSvkyybGyOwPgP01CVITggVohz0j9NGwgIVAJOcn4Hx5WCcuw==",
+      "version": "1.2.249",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.2.249.tgz",
+      "integrity": "sha512-2hiUkpRgGXEJz2+SoaZIRUuPWeBKj3PH28fN0WR9HIqbglU8gKr3LHyQKbx8SRBosYeSbRSFknw44ucK7IY9rQ==",
       "dev": true,
       "optional": true
     },
     "@swc/core-win32-arm64-msvc": {
-      "version": "1.2.246",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.2.246.tgz",
-      "integrity": "sha512-VISXunc1sU0jm5dC37TLXYTdmIcz4b9ItfrGpc+hIZWDwGbagSwHiThnJL3OlpZQrcrbZ0w+/zg4EYb5JenbXg==",
+      "version": "1.2.249",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.2.249.tgz",
+      "integrity": "sha512-lP8Gvqnj6FSnJpNkR06yd522CUS3HbS7D1ZWhxlr7xy2xB9bmQhQL3CloZONVRBU+0vvwE54p4k5X6/oJus+qQ==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -4626,9 +4611,9 @@
       }
     },
     "@swc/core-win32-ia32-msvc": {
-      "version": "1.2.246",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.2.246.tgz",
-      "integrity": "sha512-4tp3BrFur90PB2EM5vvfsw2zyBDFhC1PRAYGXJf9oF0Fnf4kQt+cBYXGy13I/kJfhd/cKQJC8o9lBV+dtLtGDg==",
+      "version": "1.2.249",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.2.249.tgz",
+      "integrity": "sha512-zm4Wj1cvmiBHShRhX33hSzI/I7FctWA6svxlsx1zEQmTtKSqUqEKoswy/XUNsJ9p6Knf9INLPItfv/7HI/Eqaw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -4645,9 +4630,9 @@
       }
     },
     "@swc/core-win32-x64-msvc": {
-      "version": "1.2.246",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.2.246.tgz",
-      "integrity": "sha512-wD22xEFdiYtpq7Nwq1k8Dqwe08zrgaEhO9rn7G9DUtjHPSeIOpNQ1dQrzGBVK5Ah/3WJuciCAyUbVtaDUROhEQ==",
+      "version": "1.2.249",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.2.249.tgz",
+      "integrity": "sha512-IxRvePerNYVJXr6lk0P09y1XAqPncMHWWvWm7p3CvTAfxEuiM5DqD5wtIbFMXfPSi1TTSkzAqBoH6Nushvgb3Q==",
       "dev": true,
       "optional": true
     },
@@ -5837,8 +5822,7 @@
     "get-tsconfig": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.2.0.tgz",
-      "integrity": "sha512-X8u8fREiYOE6S8hLbq99PeykTDoLVnxvF4DjWKJmz9xy2nNRdUcV8ZN9tniJFeKyTU3qnC9lL8n4Chd6LmVKHg==",
-      "dev": true
+      "integrity": "sha512-X8u8fREiYOE6S8hLbq99PeykTDoLVnxvF4DjWKJmz9xy2nNRdUcV8ZN9tniJFeKyTU3qnC9lL8n4Chd6LmVKHg=="
     },
     "glob": {
       "version": "7.2.0",
@@ -6187,11 +6171,6 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-    "joycon": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
-      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6228,11 +6207,6 @@
       "requires": {
         "minimist": "^1.2.0"
       }
-    },
-    "jsonc-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
     },
     "levn": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -28,13 +28,12 @@
   "dependencies": {
     "@rollup/pluginutils": "^4.2.1",
     "deepmerge": "^4.2.2",
-    "joycon": "^3.1.1",
-    "jsonc-parser": "^3.2.0"
+    "get-tsconfig": "^4.2.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^22.0.2",
     "@rollup/plugin-json": "^4.1.0",
-    "@swc/core": "^1.2.246",
+    "@swc/core": "^1.2.249",
     "@types/chai": "^4.3.3",
     "@types/mocha": "^9.1.1",
     "@types/node": "^18.7.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-swc3",
-  "version": "0.5.0",
+  "version": "0.6.0-canary.0",
   "description": "Use SWC with Rollup to transform ESNext and TypeScript code.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^22.0.2",
     "@rollup/plugin-json": "^4.1.0",
-    "@swc/core": "^1.2.249",
+    "@swc/core": "^1.3.0",
     "@types/chai": "^4.3.3",
     "@types/mocha": "^9.1.1",
     "@types/node": "^18.7.14",

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,7 @@ function swc(options: PluginOptions = {}): Plugin {
       const tsconfigOptions
         = options.tsconfig === false
           ? {}
-          : await getOptions(dirname(id), options.tsconfig);
+          : getOptions(dirname(id), options.tsconfig);
 
       // TODO: SWC is about to add "preserve" jsx
       // https://github.com/swc-project/swc/pull/5661

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,11 +1,17 @@
-import { getTsconfig } from 'get-tsconfig';
+import { getTsconfig, parseTsconfig } from 'get-tsconfig';
+import path from 'path';
 
-export const getOptions = async (
+export const getOptions = (
   cwd: string,
   tsconfig?: string
 ) => {
+  if (tsconfig && path.isAbsolute(tsconfig)) {
+    return parseTsconfig(tsconfig).compilerOptions ?? {};
+  }
+
   let result = getTsconfig(cwd, tsconfig || 'tsconfig.json');
-  if (!result) {
+  // Only fallback to `jsconfig.json` when tsconfig can not be resolved AND custom tsconfig filename is not provided
+  if (!result && !tsconfig) {
     result = getTsconfig(cwd, 'jsconfig.json');
   }
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,62 +1,13 @@
-import fs from 'fs';
-import JoyCon from 'joycon';
-import { parse } from 'jsonc-parser';
-
-const joycon = new JoyCon();
-
-joycon.addLoader({
-  test: /\.json$/,
-  load: async (file) => {
-    const content = await fs.promises.readFile(file, { encoding: 'utf-8' });
-    return parse(content);
-  }
-});
+import { getTsconfig } from 'get-tsconfig';
 
 export const getOptions = async (
   cwd: string,
   tsconfig?: string
-): Promise<{
-  importHelpers?: boolean,
-  esModuleInterop?: boolean,
-  experimentalDecorators?: boolean,
-  emitDecoratorMetadata?: boolean,
-  jsx?: 'preserve' | 'react' | 'react-jsx' | 'react-jsxdev' | 'react-native',
-  jsxFactory?: string,
-  jsxFragmentFactory?: string,
-  jsxImportSource?: string,
-  target?: string,
-  baseUrl?: string,
-  paths?: { [from: string]: [string] }
-}> => {
-  // joycon has its builtin-cache support
-  const { data, path } = await joycon.load([tsconfig || 'tsconfig.json', 'jsconfig.json'], cwd);
-  if (path && data) {
-    const {
-      importHelpers,
-      esModuleInterop,
-      experimentalDecorators,
-      emitDecoratorMetadata,
-      jsx,
-      jsxFactory,
-      jsxFragmentFactory,
-      jsxImportSource,
-      target,
-      baseUrl,
-      paths
-    } = data.compilerOptions || {};
-    return {
-      importHelpers,
-      esModuleInterop,
-      experimentalDecorators,
-      emitDecoratorMetadata,
-      jsx,
-      jsxFactory,
-      jsxFragmentFactory,
-      jsxImportSource,
-      target,
-      baseUrl,
-      paths
-    };
+) => {
+  let result = getTsconfig(cwd, tsconfig || 'tsconfig.json');
+  if (!result) {
+    result = getTsconfig(cwd, 'jsconfig.json');
   }
-  return {};
+
+  return result?.config.compilerOptions ?? {};
 };

--- a/test/index.ts
+++ b/test/index.ts
@@ -523,4 +523,31 @@ var baz = /*#__PURE__*/ h("div", null, foo, bar);\n
 export { baz };
 `);
   });
+
+  it('tsconfig - specify full path', async () => {
+    const dir = realFs(getTestName(), {
+      './fixture/index.jsx': `
+        export const foo = <div>foo</div>
+      `,
+      './fixture/foo/bar/tsconfig.json': `
+        {
+          "compilerOptions": { "jsxFactory": "hFoo" }
+        }
+      `,
+      './fixture/tsconfig.json': `
+        {
+          "compilerOptions": { "jsxFactory": "hBar" }
+        }
+      `
+    });
+
+    const tsconfigPath = path.resolve(dir, './fixture/foo/bar/tsconfig.json');
+
+    (await build(
+      { tsconfig: tsconfigPath },
+      { input: './fixture/index.jsx', dir }
+    ))[0].code.should.equal(`var foo = /*#__PURE__*/ hFoo("div", null, "foo");\n
+export { foo };
+`);
+  });
 });

--- a/test/index.ts
+++ b/test/index.ts
@@ -440,4 +440,87 @@ class Foo {
 
 console.log(Foo);\n`);
   });
+
+  it('tsconfig extends', async () => {
+    const dir = realFs(getTestName(), {
+      './fixture/index.jsx': `
+        export const foo = <div>foo</div>
+      `,
+      './fixture/tsconfig.json': `
+        {
+          "extends": "./tsconfig.build.json",
+          "compilerOptions": {}
+        }
+      `,
+      './fixture/tsconfig.build.json': `
+        {
+          "compilerOptions": {
+            "jsxFactory": "custom"
+          }
+        }
+      `,
+      './fixture/jsconfig.json': `
+        {
+          "extends": "./tsconfig.build.json",
+          "compilerOptions": {}
+        }
+      `
+    });
+
+    (await build(
+      {},
+      { input: './fixture/index.jsx', dir }
+    ))[0].code.should.equal(`var foo = /*#__PURE__*/ custom("div", null, "foo");
+
+export { foo };
+`);
+
+    (await build(
+      { tsconfig: 'jsconfig.json' },
+      { input: './fixture/index.jsx', dir }
+    ))[0].code.should.equal(`var foo = /*#__PURE__*/ custom("div", null, "foo");
+
+export { foo };
+`);
+  });
+
+  it('tsconfig resolve to nearest tsconfig', async () => {
+    const dir = realFs(getTestName(), {
+      './fixture/index.jsx': `
+        import { foo } from './foo';
+        import { bar } from './bar';
+        export const baz = <div>{foo}{bar}</div>
+      `,
+      './fixture/tsconfig.json': `
+        {
+          "compilerOptions": { "jsxFactory": "h" }
+        }
+      `,
+      './fixture/foo/index.jsx': `
+        export const foo = <div>foo</div>
+      `,
+      './fixture/foo/tsconfig.json': `
+        {
+          "compilerOptions": { "jsxFactory": "hFoo" }
+        }
+      `,
+      './fixture/bar/index.tsx': `
+        export const bar = <div>bar</div>
+      `,
+      './fixture/bar/tsconfig.json': `
+        {
+          "compilerOptions": { "jsxFactory": "hBar" }
+        }
+      `
+    });
+
+    (await build(
+      {},
+      { input: './fixture/index.jsx', dir }
+    ))[0].code.should.equal(`var foo = /*#__PURE__*/ hFoo("div", null, "foo");\n
+var bar = /*#__PURE__*/ hBar("div", null, "bar");\n
+var baz = /*#__PURE__*/ h("div", null, foo, bar);\n
+export { baz };
+`);
+  });
 });


### PR DESCRIPTION
The PR replace `joycon` & `jsonc-parser` with `get-tsconfig`, which supports `extends` in `tsconfig.json`/`jsconfig.json`.

`get-tsconfig` is also battle-tested, used by `eslint-import-resolver-typescript`, `@esbuild-kit/cjs-loader`, `@esbuild-kit/esm-loader` and many more.

I have published a canary version (`0.6.0-canary.0`) for anyone interested. Feel free to comment on this before the PR is merged.

---

cc @jack-works

The `extends` of `tsconfig.json` is now supported. And the behavior should align with the `tsc` now.

cc @huozhi

Previously, specifying a full path in the `tsconfig` option will result in undefined behavior. The `tsconfig` option is designed for a custom filename (like `tsconfig.rollup.json`) for the plugin to find. The only reason providing a full path will work is the implementation detail of the `joycon` library.

While `get-tsconfig` doesn't support passing a full path, in order to maintain backward compatibility and not break the `bunchee`, I have made that providing a full path is officially supported.

Although I have created a test case against it, please try the canary version out to see whether it will break the `bunchee`.

