### PR TITLE
feat: bring up initial support for rollup 3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,8 @@
         "get-tsconfig": "^4.2.0"
       },
       "devDependencies": {
-        "@rollup/plugin-commonjs": "^22.0.2",
-        "@rollup/plugin-json": "^4.1.0",
+        "@rollup/plugin-commonjs": "^23.0.0",
+        "@rollup/plugin-json": "^5.0.0",
         "@swc/core": "^1.3.2",
         "@types/chai": "^4.3.3",
         "@types/mocha": "^9.1.1",
@@ -29,9 +29,9 @@
         "eslint-plugin-import": "^2.26.0",
         "mocha": "^10.0.0",
         "rimraf": "^3.0.2",
-        "rollup": "^2.79.1",
-        "rollup-plugin-dts": "^4.2.2",
-        "rollup3": "npm:rollup@^3.0.0",
+        "rollup": "^3.2.0",
+        "rollup-plugin-dts": "^5.0.0",
+        "rollup2": "npm:rollup@^2.79.1",
         "ts-mocha": "^10.0.0",
         "ts-node": "^10.9.1",
         "typescript": "^4.8.3"
@@ -41,26 +41,26 @@
       },
       "peerDependencies": {
         "@swc/core": ">=1.2.165",
-        "rollup": "^2.0.0 || ^3.0.0"
+        "rollup": "^2.0.0 || ^3.2.0"
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
-      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
       "dev": true,
       "optional": true,
       "dependencies": {
-        "@babel/highlight": "^7.16.7"
+        "@babel/highlight": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
       "dev": true,
       "optional": true,
       "engines": {
@@ -68,13 +68,13 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.17.9",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.9.tgz",
-      "integrity": "sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
       "dev": true,
       "optional": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -252,83 +252,89 @@
       "dev": true
     },
     "node_modules/@rollup/plugin-commonjs": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-22.0.2.tgz",
-      "integrity": "sha512-//NdP6iIwPbMTcazYsiBMbJW7gfmpHom33u1beiIoHDEM0Q9clvtQB1T0efvMqHeKsGohiHo97BCPCkBXdscwg==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-23.0.0.tgz",
+      "integrity": "sha512-JbrTRyDNtLQj/rhl7RFUuYXwQ2fac+33oLDAu2k++WD95zweyo28UAomLVA0JMGx4vmCa7Nw4T6k/1F6lelExg==",
       "dev": true,
       "dependencies": {
-        "@rollup/pluginutils": "^3.1.0",
+        "@rollup/pluginutils": "^4.2.1",
         "commondir": "^1.0.1",
-        "estree-walker": "^2.0.1",
-        "glob": "^7.1.6",
-        "is-reference": "^1.2.1",
-        "magic-string": "^0.25.7",
-        "resolve": "^1.17.0"
+        "estree-walker": "^2.0.2",
+        "glob": "^8.0.3",
+        "is-reference": "1.2.1",
+        "magic-string": "^0.26.4"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "rollup": "^2.68.0"
+        "rollup": "^2.68.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@rollup/plugin-commonjs/node_modules/@rollup/pluginutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
-      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+    "node_modules/@rollup/plugin-commonjs/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
       "dependencies": {
-        "@types/estree": "0.0.39",
-        "estree-walker": "^1.0.1",
-        "picomatch": "^2.2.2"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0"
+        "balanced-match": "^1.0.0"
       }
     },
-    "node_modules/@rollup/plugin-commonjs/node_modules/@rollup/pluginutils/node_modules/estree-walker": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-      "dev": true
+    "node_modules/@rollup/plugin-commonjs/node_modules/glob": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/minimatch": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@rollup/plugin-json": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
-      "integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-5.0.0.tgz",
+      "integrity": "sha512-LsWDA5wJs/ggzakVuKQhZo7HPRcQZgBa3jWIVxQSFxaRToUGNi8ZBh3+k/gQ+1eInVYJgn4WBRCUkmoDrmmGzw==",
       "dev": true,
       "dependencies": {
-        "@rollup/pluginutils": "^3.0.8"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0 || ^2.0.0"
-      }
-    },
-    "node_modules/@rollup/plugin-json/node_modules/@rollup/pluginutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
-      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "0.0.39",
-        "estree-walker": "^1.0.1",
-        "picomatch": "^2.2.2"
+        "@rollup/pluginutils": "^4.2.1"
       },
       "engines": {
-        "node": ">= 8.0.0"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0"
+        "rollup": "^1.20.0||^2.0.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
       }
-    },
-    "node_modules/@rollup/plugin-json/node_modules/estree-walker": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-      "dev": true
     },
     "node_modules/@rollup/pluginutils": {
       "version": "4.2.1",
@@ -1257,7 +1263,7 @@
     "node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true,
       "optional": true
     },
@@ -1495,7 +1501,7 @@
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
       "optional": true,
       "engines": {
@@ -2331,7 +2337,7 @@
     "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
       "optional": true,
       "engines": {
@@ -2910,12 +2916,15 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
+      "integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
       "dev": true,
       "dependencies": {
-        "sourcemap-codec": "^1.4.4"
+        "sourcemap-codec": "^1.4.8"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/make-error": {
@@ -3463,6 +3472,45 @@
       }
     },
     "node_modules/rollup": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.2.0.tgz",
+      "integrity": "sha512-0ZkFPyBNvx717KvC700NoxUD31aEEX675u6INJVAmBgKtQuCL8jmmJCj1b9B/qDSnILAvASVKa7UpGS+FLN6AQ==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-plugin-dts": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-5.0.0.tgz",
+      "integrity": "sha512-OO8ayCvuJCKaQSShyVTARxGurVVk4ulzbuvz+0zFd1f93vlnWFU5pBMT7HFeS6uj7MvvZLx4kUAarGATSU1+Ng==",
+      "dev": true,
+      "dependencies": {
+        "magic-string": "^0.26.7"
+      },
+      "engines": {
+        "node": ">=v14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Swatinem"
+      },
+      "optionalDependencies": {
+        "@babel/code-frame": "^7.18.6"
+      },
+      "peerDependencies": {
+        "rollup": "^3.0.0",
+        "typescript": "^4.1"
+      }
+    },
+    "node_modules/rollup2": {
+      "name": "rollup",
       "version": "2.79.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
       "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
@@ -3472,57 +3520,6 @@
       },
       "engines": {
         "node": ">=10.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/rollup-plugin-dts": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-4.2.2.tgz",
-      "integrity": "sha512-A3g6Rogyko/PXeKoUlkjxkP++8UDVpgA7C+Tdl77Xj4fgEaIjPSnxRmR53EzvoYy97VMVwLAOcWJudaVAuxneQ==",
-      "dev": true,
-      "dependencies": {
-        "magic-string": "^0.26.1"
-      },
-      "engines": {
-        "node": ">=v12.22.11"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/Swatinem"
-      },
-      "optionalDependencies": {
-        "@babel/code-frame": "^7.16.7"
-      },
-      "peerDependencies": {
-        "rollup": "^2.55",
-        "typescript": "^4.1"
-      }
-    },
-    "node_modules/rollup-plugin-dts/node_modules/magic-string": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.1.tgz",
-      "integrity": "sha512-ndThHmvgtieXe8J/VGPjG+Apu7v7ItcD5mhEIvOscWjPF/ccOiLxHaSuCAS2G+3x4GKsAbT8u7zdyamupui8Tg==",
-      "dev": true,
-      "dependencies": {
-        "sourcemap-codec": "^1.4.8"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/rollup3": {
-      "name": "rollup",
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.0.0.tgz",
-      "integrity": "sha512-iVomS2lySi4BM2QJb7lGZBjSndUEs6Ip+VDl25jcbM99VI5vWeEitvUSiNQkQkwqEiI4515m5shjyuwPcXS5Dg==",
-      "dev": true,
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=14.18.0",
-        "npm": ">=8.0.0"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
@@ -4249,30 +4246,30 @@
   },
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
-      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
       "dev": true,
       "optional": true,
       "requires": {
-        "@babel/highlight": "^7.16.7"
+        "@babel/highlight": "^7.18.6"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
       "dev": true,
       "optional": true
     },
     "@babel/highlight": {
-      "version": "7.17.9",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.9.tgz",
-      "integrity": "sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
       "dev": true,
       "optional": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       }
@@ -4408,67 +4405,59 @@
       }
     },
     "@rollup/plugin-commonjs": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-22.0.2.tgz",
-      "integrity": "sha512-//NdP6iIwPbMTcazYsiBMbJW7gfmpHom33u1beiIoHDEM0Q9clvtQB1T0efvMqHeKsGohiHo97BCPCkBXdscwg==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-23.0.0.tgz",
+      "integrity": "sha512-JbrTRyDNtLQj/rhl7RFUuYXwQ2fac+33oLDAu2k++WD95zweyo28UAomLVA0JMGx4vmCa7Nw4T6k/1F6lelExg==",
       "dev": true,
       "requires": {
-        "@rollup/pluginutils": "^3.1.0",
+        "@rollup/pluginutils": "^4.2.1",
         "commondir": "^1.0.1",
-        "estree-walker": "^2.0.1",
-        "glob": "^7.1.6",
-        "is-reference": "^1.2.1",
-        "magic-string": "^0.25.7",
-        "resolve": "^1.17.0"
+        "estree-walker": "^2.0.2",
+        "glob": "^8.0.3",
+        "is-reference": "1.2.1",
+        "magic-string": "^0.26.4"
       },
       "dependencies": {
-        "@rollup/pluginutils": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
-          "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
           "dev": true,
           "requires": {
-            "@types/estree": "0.0.39",
-            "estree-walker": "^1.0.1",
-            "picomatch": "^2.2.2"
-          },
-          "dependencies": {
-            "estree-walker": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-              "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-              "dev": true
-            }
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "glob": {
+          "version": "8.0.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+          "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
           }
         }
       }
     },
     "@rollup/plugin-json": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
-      "integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-5.0.0.tgz",
+      "integrity": "sha512-LsWDA5wJs/ggzakVuKQhZo7HPRcQZgBa3jWIVxQSFxaRToUGNi8ZBh3+k/gQ+1eInVYJgn4WBRCUkmoDrmmGzw==",
       "dev": true,
       "requires": {
-        "@rollup/pluginutils": "^3.0.8"
-      },
-      "dependencies": {
-        "@rollup/pluginutils": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
-          "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
-          "dev": true,
-          "requires": {
-            "@types/estree": "0.0.39",
-            "estree-walker": "^1.0.1",
-            "picomatch": "^2.2.2"
-          }
-        },
-        "estree-walker": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-          "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-          "dev": true
-        }
+        "@rollup/pluginutils": "^4.2.1"
       }
     },
     "@rollup/pluginutils": {
@@ -5098,7 +5087,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true,
       "optional": true
     },
@@ -5282,7 +5271,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
       "optional": true
     },
@@ -5919,7 +5908,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
       "optional": true
     },
@@ -6326,12 +6315,12 @@
       }
     },
     "magic-string": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
+      "integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
       "dev": true,
       "requires": {
-        "sourcemap-codec": "^1.4.4"
+        "sourcemap-codec": "^1.4.8"
       }
     },
     "make-error": {
@@ -6711,39 +6700,28 @@
       }
     },
     "rollup": {
-      "version": "2.79.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.2.0.tgz",
+      "integrity": "sha512-0ZkFPyBNvx717KvC700NoxUD31aEEX675u6INJVAmBgKtQuCL8jmmJCj1b9B/qDSnILAvASVKa7UpGS+FLN6AQ==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
       }
     },
     "rollup-plugin-dts": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-4.2.2.tgz",
-      "integrity": "sha512-A3g6Rogyko/PXeKoUlkjxkP++8UDVpgA7C+Tdl77Xj4fgEaIjPSnxRmR53EzvoYy97VMVwLAOcWJudaVAuxneQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-5.0.0.tgz",
+      "integrity": "sha512-OO8ayCvuJCKaQSShyVTARxGurVVk4ulzbuvz+0zFd1f93vlnWFU5pBMT7HFeS6uj7MvvZLx4kUAarGATSU1+Ng==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.16.7",
-        "magic-string": "^0.26.1"
-      },
-      "dependencies": {
-        "magic-string": {
-          "version": "0.26.1",
-          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.1.tgz",
-          "integrity": "sha512-ndThHmvgtieXe8J/VGPjG+Apu7v7ItcD5mhEIvOscWjPF/ccOiLxHaSuCAS2G+3x4GKsAbT8u7zdyamupui8Tg==",
-          "dev": true,
-          "requires": {
-            "sourcemap-codec": "^1.4.8"
-          }
-        }
+        "@babel/code-frame": "^7.18.6",
+        "magic-string": "^0.26.7"
       }
     },
-    "rollup3": {
-      "version": "npm:rollup@3.0.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.0.0.tgz",
-      "integrity": "sha512-iVomS2lySi4BM2QJb7lGZBjSndUEs6Ip+VDl25jcbM99VI5vWeEitvUSiNQkQkwqEiI4515m5shjyuwPcXS5Dg==",
+    "rollup2": {
+      "version": "npm:rollup@2.79.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
+      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "rimraf": "^3.0.2",
         "rollup": "^2.79.1",
         "rollup-plugin-dts": "^4.2.2",
+        "rollup3": "npm:rollup@^3.0.0",
         "ts-mocha": "^10.0.0",
         "ts-node": "^10.9.1",
         "typescript": "^4.8.3"
@@ -40,7 +41,7 @@
       },
       "peerDependencies": {
         "@swc/core": ">=1.2.165",
-        "rollup": "^2.0.0"
+        "rollup": "^2.0.0 || ^3.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3510,6 +3511,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/rollup3": {
+      "name": "rollup",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.0.0.tgz",
+      "integrity": "sha512-iVomS2lySi4BM2QJb7lGZBjSndUEs6Ip+VDl25jcbM99VI5vWeEitvUSiNQkQkwqEiI4515m5shjyuwPcXS5Dg==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -6720,6 +6738,15 @@
             "sourcemap-codec": "^1.4.8"
           }
         }
+      }
+    },
+    "rollup3": {
+      "version": "npm:rollup@3.0.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.0.0.tgz",
+      "integrity": "sha512-iVomS2lySi4BM2QJb7lGZBjSndUEs6Ip+VDl25jcbM99VI5vWeEitvUSiNQkQkwqEiI4515m5shjyuwPcXS5Dg==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.3.2"
       }
     },
     "run-parallel": {

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "get-tsconfig": "^4.2.0"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^22.0.2",
-    "@rollup/plugin-json": "^4.1.0",
+    "@rollup/plugin-commonjs": "^23.0.0",
+    "@rollup/plugin-json": "^5.0.0",
     "@swc/core": "^1.3.2",
     "@types/chai": "^4.3.3",
     "@types/mocha": "^9.1.1",
@@ -46,16 +46,16 @@
     "eslint-plugin-import": "^2.26.0",
     "mocha": "^10.0.0",
     "rimraf": "^3.0.2",
-    "rollup": "^2.79.1",
-    "rollup-plugin-dts": "^4.2.2",
-    "rollup3": "npm:rollup@^3.0.0",
+    "rollup": "^3.2.0",
+    "rollup-plugin-dts": "^5.0.0",
+    "rollup2": "npm:rollup@^2.79.1",
     "ts-mocha": "^10.0.0",
     "ts-node": "^10.9.1",
     "typescript": "^4.8.3"
   },
   "peerDependencies": {
     "@swc/core": ">=1.2.165",
-    "rollup": "^2.0.0 || ^3.0.0"
+    "rollup": "^2.0.0 || ^3.2.0"
   },
   "engines": {
     "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -48,13 +48,14 @@
     "rimraf": "^3.0.2",
     "rollup": "^2.79.1",
     "rollup-plugin-dts": "^4.2.2",
+    "rollup3": "npm:rollup@^3.0.0",
     "ts-mocha": "^10.0.0",
     "ts-node": "^10.9.1",
     "typescript": "^4.8.3"
   },
   "peerDependencies": {
     "@swc/core": ">=1.2.165",
-    "rollup": "^2.0.0"
+    "rollup": "^2.0.0 || ^3.0.0"
   },
   "engines": {
     "node": ">=12"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from 'rollup';
+import type { Plugin as RollupPlugin } from 'rollup';
 
 import fs from 'fs';
 import { extname, resolve, dirname, join } from 'path';
@@ -55,7 +55,7 @@ const resolveFile = async (resolved: string, index = false) => {
   return null;
 };
 
-function swc(options: PluginOptions = {}): Plugin {
+function swc(options: PluginOptions = {}): RollupPlugin {
   const filter = createFilter(
     options.include || INCLUDE_REGEXP,
     options.exclude || EXCLUDE_REGEXP
@@ -177,7 +177,7 @@ function swc(options: PluginOptions = {}): Plugin {
   };
 }
 
-function minify(options: JsMinifyOptions = {}): Plugin {
+function minify(options: JsMinifyOptions = {}): RollupPlugin {
   return {
     name: 'swc-minify',
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import fs from 'fs';
-import { rollup, type Plugin as RollupPlugin, type ExternalOption } from 'rollup';
-import { rollup as rollup3 } from 'rollup3';
+import { rollup } from 'rollup2';
+import { rollup as rollup3, type Plugin as RollupPlugin, type ExternalOption } from 'rollup';
 
 import { swc, type PluginOptions, minify } from '../src';
 import json from '@rollup/plugin-json';
@@ -62,7 +62,7 @@ const runMinify = async (
 ) => {
   const build = await rollup({
     input: [...(Array.isArray(input) ? input : [input])].map((v) => path.resolve(dir, v)),
-    plugins: [...otherRollupPlugins, minify(options)]
+    plugins: [...otherRollupPlugins, minify(options)] as any
   });
   const { output } = await build.generate({ format: 'esm', sourcemap });
   return output;

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,6 +1,8 @@
 import path from 'path';
 import fs from 'fs';
 import { rollup, type Plugin as RollupPlugin, type ExternalOption } from 'rollup';
+import { rollup as rollup3 } from 'rollup3';
+
 import { swc, type PluginOptions, minify } from '../src';
 import json from '@rollup/plugin-json';
 import commonjs from '@rollup/plugin-commonjs';
@@ -24,6 +26,7 @@ const realFs = (folderName: string, files: Record<string, string>) => {
 };
 
 const build = async (
+  rollupImpl: typeof rollup | typeof rollup3,
   options?: PluginOptions,
   {
     input = './fixture/index.js',
@@ -39,9 +42,9 @@ const build = async (
     external?: ExternalOption
   } = {}
 ) => {
-  const build = await rollup({
+  const build = await rollupImpl({
     input: [...(Array.isArray(input) ? input : [input])].map((v) => path.resolve(dir, v)),
-    plugins: [...otherRollupPlugins, swc(options)],
+    plugins: [...otherRollupPlugins, swc(options)] as any,
     external
   });
   const { output } = await build.generate({ format: 'esm', sourcemap });
@@ -67,13 +70,7 @@ const runMinify = async (
 
 const getTestName = () => String(Date.now());
 
-describe('swc', () => {
-  after(() => {
-    if (fs.existsSync(tmpDir)) {
-      fs.rmSync(tmpDir, { recursive: true });
-    }
-  });
-
+const tests = (rollupImpl: typeof rollup | typeof rollup3) => {
   it('simple', async () => {
     const dir = realFs(getTestName(), {
       './fixture/index.js': `
@@ -94,7 +91,7 @@ describe('swc', () => {
         export default bar
       `
     });
-    const output = await build({}, { dir });
+    const output = await build(rollupImpl, {}, { dir });
     output[0].code.should.equal(`function _classCallCheck(instance, Constructor) {
     if (!(instance instanceof Constructor)) {
         throw new TypeError("Cannot call a class as a function");
@@ -133,7 +130,7 @@ console.log(bar);\n`);
         }
       `
     });
-    const output = await build({ minify: true, jsc: { target: 'es2022' } }, { dir });
+    const output = await build(rollupImpl, { minify: true, jsc: { target: 'es2022' } }, { dir });
     output[0].code.should.equal('class e{render(){return React.createElement("div",{className:"hehe"},"hello there!!!")}}console.log(e);\n');
   });
 
@@ -163,7 +160,7 @@ console.log(bar);\n`);
       `
     });
 
-    const output = await build({ jsc: { target: 'es2022' } }, { dir });
+    const output = await build(rollupImpl, { jsc: { target: 'es2022' } }, { dir });
 
     output[0].code.should.equal(`class Foo {
     render() {
@@ -191,6 +188,7 @@ console.log(Foo);
     });
 
     const output = await build(
+      rollupImpl,
       {},
       { otherRollupPlugins: [json()], dir }
     );
@@ -219,6 +217,7 @@ console.log(foo$1);
       `
     });
     const output = await build(
+      rollupImpl,
       { jsc: { target: 'es2022' } },
       { otherRollupPlugins: [commonjs()], dir }
     );
@@ -252,7 +251,7 @@ export { fixture as default };
       `
     });
 
-    const output = await build({}, { input: './fixture/index.tsx', dir });
+    const output = await build(rollupImpl, {}, { input: './fixture/index.tsx', dir });
     output[0].code.should.equal(`var foo = /*#__PURE__*/ h("div", null, "foo");
 
 export { foo };\n`);
@@ -272,7 +271,7 @@ export { foo };\n`);
       `
     });
 
-    const output = await build({}, { input: './fixture/index.tsx', dir });
+    const output = await build(rollupImpl, {}, { input: './fixture/index.tsx', dir });
     output[0].code.should.equal(`var foo = /*#__PURE__*/ h("div", null, "foo");
 
 export { foo };\n`);
@@ -308,7 +307,7 @@ export { foo };\n`);
     });
 
     (
-      await build({ tsconfig: 'tsconfig.react-jsx.json' }, { input: './fixture/index.tsx', dir, external: 'react/jsx-runtime' })
+      await build(rollupImpl, { tsconfig: 'tsconfig.react-jsx.json' }, { input: './fixture/index.tsx', dir, external: 'react/jsx-runtime' })
     )[0].code.should.equal(`import { jsx } from 'react/jsx-runtime';
 
 function Foo() {
@@ -320,7 +319,7 @@ function Foo() {
 export { Foo };\n`);
 
     (
-      await build({ tsconfig: 'tsconfig.react-jsxdev.json' }, { input: './fixture/index.tsx', dir, external: 'react/jsx-dev-runtime' })
+      await build(rollupImpl, { tsconfig: 'tsconfig.react-jsxdev.json' }, { input: './fixture/index.tsx', dir, external: 'react/jsx-dev-runtime' })
     )[0].code.should.equal(`import { jsxDEV } from 'react/jsx-dev-runtime';
 
 function Foo() {
@@ -336,7 +335,7 @@ function Foo() {
 export { Foo };\n`);
 
     (
-      await build({ tsconfig: 'tsconfig.compiled.json' }, { input: './fixture/index.tsx', dir, external: '@compiled/react/jsx-runtime' })
+      await build(rollupImpl, { tsconfig: 'tsconfig.compiled.json' }, { input: './fixture/index.tsx', dir, external: '@compiled/react/jsx-runtime' })
     )[0].code.should.equal(`import { jsx } from '@compiled/react/jsx-runtime';
 
 function Foo() {
@@ -369,7 +368,7 @@ export { Foo };\n`);
     `
     });
 
-    const output = await build({}, { input: './fixture/index.tsx', dir });
+    const output = await build(rollupImpl, {}, { input: './fixture/index.tsx', dir });
     output[0].code.should.equal(`var foo = /*#__PURE__*/ React.createElement(React.Fragment, null, /*#__PURE__*/ React.createElement("div", null, "foo"));
 
 export { foo };
@@ -398,6 +397,7 @@ export { foo };
     });
 
     const output = await build(
+      rollupImpl,
       { tsconfig: 'tsconfig.build.json' },
       { input: './fixture/index.jsx', dir }
     );
@@ -427,7 +427,7 @@ export { foo };
       `
     });
 
-    const output = await build({ jsc: { target: 'es2022' } }, { dir });
+    const output = await build(rollupImpl, { jsc: { target: 'es2022' } }, { dir });
     output[0].code.should.eq(`const util = 42;
 
 class Foo {
@@ -468,6 +468,7 @@ console.log(Foo);\n`);
     });
 
     (await build(
+      rollupImpl,
       {},
       { input: './fixture/index.jsx', dir }
     ))[0].code.should.equal(`var foo = /*#__PURE__*/ custom("div", null, "foo");
@@ -476,6 +477,7 @@ export { foo };
 `);
 
     (await build(
+      rollupImpl,
       { tsconfig: 'jsconfig.json' },
       { input: './fixture/index.jsx', dir }
     ))[0].code.should.equal(`var foo = /*#__PURE__*/ custom("div", null, "foo");
@@ -515,6 +517,7 @@ export { foo };
     });
 
     (await build(
+      rollupImpl,
       {},
       { input: './fixture/index.jsx', dir }
     ))[0].code.should.equal(`var foo = /*#__PURE__*/ hFoo("div", null, "foo");\n
@@ -544,10 +547,31 @@ export { baz };
     const tsconfigPath = path.resolve(dir, './fixture/foo/bar/tsconfig.json');
 
     (await build(
+      rollupImpl,
       { tsconfig: tsconfigPath },
       { input: './fixture/index.jsx', dir }
     ))[0].code.should.equal(`var foo = /*#__PURE__*/ hFoo("div", null, "foo");\n
 export { foo };
 `);
   });
+};
+
+describe('swc (rollup 2)', () => {
+  after(() => {
+    if (fs.existsSync(tmpDir)) {
+      fs.rmSync(tmpDir, { recursive: true });
+    }
+  });
+
+  tests(rollup);
+});
+
+describe('swc (rollup 3)', () => {
+  after(() => {
+    if (fs.existsSync(tmpDir)) {
+      fs.rmSync(tmpDir, { recursive: true });
+    }
+  });
+
+  tests(rollup3);
 });

--- a/tools/build.ts
+++ b/tools/build.ts
@@ -1,4 +1,4 @@
-import module from 'module';
+import { builtinModules } from 'module';
 
 import { rollup as rollup2 } from 'rollup';
 import { rollup as rollup3 } from 'rollup3';
@@ -8,9 +8,10 @@ import { swc, defineRollupSwcOption } from '../src/index';
 
 import pkg from '../package.json';
 const deps = Object.keys(pkg.dependencies);
+const peerDeps = Object.keys(pkg.peerDependencies);
 
 async function main() {
-  const external = ['@swc/core', ...deps, ...module.builtinModules];
+  const external = [...deps, ...peerDeps, ...builtinModules];
 
   async function build() {
     const bundle = await rollup3({
@@ -20,6 +21,9 @@ async function main() {
         jsc: {
           target: 'es2019'
         }
+      // The return type of swc() is `import('rollup2').Plugin` while the required type is `import('rollup3').Plugin`
+      // Although they are identical, typescript is not happy about that
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       })) as any]
     });
 

--- a/tools/build.ts
+++ b/tools/build.ts
@@ -1,7 +1,6 @@
 import { builtinModules } from 'module';
 
-import { rollup as rollup2 } from 'rollup';
-import { rollup as rollup3 } from 'rollup3';
+import { rollup } from 'rollup';
 
 import dts from 'rollup-plugin-dts';
 import { swc, defineRollupSwcOption } from '../src/index';
@@ -14,7 +13,7 @@ async function main() {
   const external = [...deps, ...peerDeps, ...builtinModules];
 
   async function build() {
-    const bundle = await rollup3({
+    const bundle = await rollup({
       input: './src/index.ts',
       external,
       plugins: [swc(defineRollupSwcOption({
@@ -34,8 +33,7 @@ async function main() {
   }
 
   async function createDtsFile() {
-    // rollup-plugin-dts not yet support rollup 3, use rollup 2 to build the d.ts file
-    const bundle = await rollup2({
+    const bundle = await rollup({
       input: './src/index.ts',
       external,
       plugins: [dts()]

--- a/tools/build.ts
+++ b/tools/build.ts
@@ -1,5 +1,7 @@
 import module from 'module';
-import { rollup } from 'rollup';
+
+import { rollup as rollup2 } from 'rollup';
+import { rollup as rollup3 } from 'rollup3';
 
 import dts from 'rollup-plugin-dts';
 import { swc, defineRollupSwcOption } from '../src/index';
@@ -11,24 +13,25 @@ async function main() {
   const external = ['@swc/core', ...deps, ...module.builtinModules];
 
   async function build() {
-    const bundle = await rollup({
+    const bundle = await rollup3({
       input: './src/index.ts',
       external,
       plugins: [swc(defineRollupSwcOption({
         jsc: {
           target: 'es2019'
         }
-      }))]
+      })) as any]
     });
 
     return Promise.all([
-      bundle.write({ file: './dist/index.js', format: 'cjs', exports: 'named' }),
-      bundle.write({ file: './dist/index.mjs', format: 'esm', exports: 'named' })
+      bundle.write({ file: './dist/index.js', format: 'cjs', exports: 'named', interop: 'auto' }),
+      bundle.write({ file: './dist/index.mjs', format: 'esm', exports: 'named', interop: 'auto' })
     ]);
   }
 
   async function createDtsFile() {
-    const bundle = await rollup({
+    // rollup-plugin-dts not yet support rollup 3, use rollup 2 to build the d.ts file
+    const bundle = await rollup2({
       input: './src/index.ts',
       external,
       plugins: [dts()]


### PR DESCRIPTION
The initial attempt to add rollup 3.0.0 support.

- Bump peerDependencies to include `^3.0.0`
- Use rollup@3 to build the plugin
- Add test against both rollup@2 and rollup@3