### PR TITLE
feat: add extensions option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { getOptions } from './options';
 export type PluginOptions = {
   include?: FilterPattern
   exclude?: FilterPattern
+  extensions?: string[]
   /**
    * Use given tsconfig file instead
    * Disable it by setting to `false`
@@ -60,6 +61,7 @@ function swc(options: PluginOptions = {}): RollupPlugin {
     options.include || INCLUDE_REGEXP,
     options.exclude || EXCLUDE_REGEXP
   );
+  const extensions = ACCEPTED_EXTENSIONS.concat(options.extensions || []);
 
   return {
     name: 'swc',
@@ -92,7 +94,7 @@ function swc(options: PluginOptions = {}): RollupPlugin {
 
       const ext = extname(id);
 
-      if (!ACCEPTED_EXTENSIONS.includes(ext)) return null;
+      if (!extensions.includes(ext)) return null;
 
       const isTypeScript = ext === '.ts' || ext === '.tsx';
       const isTsx = ext === '.tsx';


### PR DESCRIPTION
To solve the problem of const es5 syntax after vue compilation

Here's the problem：
https://github.com/vuejs/rollup-plugin-vue/issues/236


Step 2 does not contain. vue，unable to compile with swc

![image](https://user-images.githubusercontent.com/38740836/201005947-501266c1-c9e0-4cc3-aeb2-9f7f7916df86.png)

```js
const ACCEPTED_EXTENSIONS = ['.ts', '.tsx', '.mjs', '.js', '.cjs', '.jsx']
```




