### PR TITLE
docs: update vue jsx usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,9 +184,6 @@ export default {
       jsc: {
         experimental: {
           plugins: [['swc-plugin-vue-jsx', {}]] // npm i swc-plugin-vue-jsx
-          // To using this plugin
-          // you need install them
-          // npm i -D swc-plugin-vue-jsx
         }
       }
     })),

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ export default {
     swc(defineRollupSwcOption({
       jsc: {
         experimental: {
-          plugins: [['swc-plugin-vue-jsx', {}]]
+          plugins: [['swc-plugin-vue-jsx', {}]] // npm i swc-plugin-vue-jsx
           // To using this plugin
           // you need install them
           // npm i -D swc-plugin-vue-jsx

--- a/README.md
+++ b/README.md
@@ -174,20 +174,19 @@ You can either configure it in your `tsconfig.json` or in your `rollup.config.js
 
 ```js
 // Vue JSX
-import vueJsx from 'rollup-plugin-vue-jsx-compat'
 import { swc, defineRollupSwcOption } from 'rollup-plugin-swc3';
 
 export default {
   input: 'xxxx',
   output: {},
   plugins: [
-    vueJsx(),
     swc(defineRollupSwcOption({
       jsc: {
-        transform: {
-          react: {
-              pragma: 'vueJsxCompat'
-          }
+        experimental: {
+          plugins: [['swc-plugin-vue-jsx', {}]]
+          // To using this plugin
+          // you need install them
+          // npm i -D swc-plugin-vue-jsx
         }
       }
     })),
@@ -203,7 +202,6 @@ export default {
   input: 'xxxx',
   output: {},
   plugins: [
-    vueJsx(),
     swc(defineRollupSwcOption({
       jsc: {
         transform:{


### PR DESCRIPTION
# Background

Currently. [swc-plgin-vue-jsx](https://github.com/g-plane/swc-plugin-vue-jsx) is same as babel plugin.
So. I think we shouldn't need `vue-jsx-compat` anymore. ( and this way can be faster.
