### PR TITLE
fix: fix PluginOptions.exclude type error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ export type PluginOptions = {
    * Disable it by setting to `false`
    */
   tsconfig?: string | false | undefined
-} & Pick<SwcOptions, Exclude<keyof SwcOptions, 'filename' & 'include' & 'exclude'>>;
+} & Omit<SwcOptions, 'filename' | 'include' | 'exclude'>;
 
 const INCLUDE_REGEXP = /\.[mc]?[jt]sx?$/;
 const EXCLUDE_REGEXP = /node_modules/;


### PR DESCRIPTION
```typescript
defineRollupSwcOption({
  exclude: /.*/,
//          ^?now is error
  jsc: {
    target: 'es2019'
  }
})
```