### PR TITLE
feat: implement `preserve-directive-plugin`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "get-tsconfig": "^4.6.2"
       },
       "devDependencies": {
+        "@napi-rs/magic-string": "^0.3.4",
         "@rollup/plugin-commonjs": "^23.0.7",
         "@rollup/plugin-json": "^5.0.2",
         "@swc-node/register": "^1.6.6",
@@ -276,6 +277,238 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
       "dev": true
+    },
+    "node_modules/@napi-rs/magic-string": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/magic-string/-/magic-string-0.3.4.tgz",
+      "integrity": "sha512-DEWl/B99RQsyMT3F9bvrXuhL01/eIQp/dtNSE3G1jQ4mTGRcP4iHWxoPZ577WrbjUinrNgvRA5+08g8fkPgimQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@napi-rs/magic-string-android-arm-eabi": "0.3.4",
+        "@napi-rs/magic-string-android-arm64": "0.3.4",
+        "@napi-rs/magic-string-darwin-arm64": "0.3.4",
+        "@napi-rs/magic-string-darwin-x64": "0.3.4",
+        "@napi-rs/magic-string-freebsd-x64": "0.3.4",
+        "@napi-rs/magic-string-linux-arm-gnueabihf": "0.3.4",
+        "@napi-rs/magic-string-linux-arm64-gnu": "0.3.4",
+        "@napi-rs/magic-string-linux-arm64-musl": "0.3.4",
+        "@napi-rs/magic-string-linux-x64-gnu": "0.3.4",
+        "@napi-rs/magic-string-linux-x64-musl": "0.3.4",
+        "@napi-rs/magic-string-win32-arm64-msvc": "0.3.4",
+        "@napi-rs/magic-string-win32-ia32-msvc": "0.3.4",
+        "@napi-rs/magic-string-win32-x64-msvc": "0.3.4"
+      }
+    },
+    "node_modules/@napi-rs/magic-string-android-arm-eabi": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-android-arm-eabi/-/magic-string-android-arm-eabi-0.3.4.tgz",
+      "integrity": "sha512-sszAYxqtzzJ4FDerDNHcqL9NhqPhj8W4DNiOanXYy50mA5oojlRtaAFPiB5ZMrWDBM32v5Q30LrmxQ4eTtu2Dg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/magic-string-android-arm64": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-android-arm64/-/magic-string-android-arm64-0.3.4.tgz",
+      "integrity": "sha512-jdQ6HuO0X5rkX4MauTcWR4HWdgjakTOmmzqXg8L26+jOHVVG1LZE+Su5qvV4bP8vMb2h+vPE+JsnwqSmWymu3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/magic-string-darwin-arm64": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-darwin-arm64/-/magic-string-darwin-arm64-0.3.4.tgz",
+      "integrity": "sha512-6NmMtvURce9/oq09XBZmuIeI6lPLGtEJ2ZPO/QzL3nLZa6wygiCnO/sFACKYNg5/73ET5HMMTeuogE1JI+r2Lw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/magic-string-darwin-x64": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-darwin-x64/-/magic-string-darwin-x64-0.3.4.tgz",
+      "integrity": "sha512-f9LmfMiUAKDOtl0meOuLYeVb6OERrgGzrTg1Tn3R3fTAShM2kxRbfAuPE9ljuXxIFzOv/uqRNLSl/LqCJwpREA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/magic-string-freebsd-x64": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-freebsd-x64/-/magic-string-freebsd-x64-0.3.4.tgz",
+      "integrity": "sha512-rqduQ4odiDK4QdM45xHWRTU4wtFIfpp8g8QGpz+3qqg7ivldDqbbNOrBaf6Oeu77uuEvWggnkyuChotfKgJdJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/magic-string-linux-arm-gnueabihf": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-linux-arm-gnueabihf/-/magic-string-linux-arm-gnueabihf-0.3.4.tgz",
+      "integrity": "sha512-pVaJEdEpiPqIfq3M4+yMAATS7Z9muDcWYn8H7GFH1ygh8GwgLgKfy/n/lG2M6zp18Mwd0x7E2E/qg9GgCyUzoQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/magic-string-linux-arm64-gnu": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-linux-arm64-gnu/-/magic-string-linux-arm64-gnu-0.3.4.tgz",
+      "integrity": "sha512-9FwoAih/0tzEZx0BjYYIxWkSRMjonIn91RFM3q3MBs/evmThXUYXUqLNa1PPIkK1JoksswtDi48qWWLt8nGflQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/magic-string-linux-arm64-musl": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-linux-arm64-musl/-/magic-string-linux-arm64-musl-0.3.4.tgz",
+      "integrity": "sha512-wCR7R+WPOcAKmVQc1s6h6HwfwW1vL9pM8BjUY9Ljkdb8wt1LmZEmV2Sgfc1SfbRQzbyl+pKeufP6adRRQVzYDA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/magic-string-linux-x64-gnu": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-linux-x64-gnu/-/magic-string-linux-x64-gnu-0.3.4.tgz",
+      "integrity": "sha512-sbxFDpYnt5WFbxQ1xozwOvh5A7IftqSI0WnE9O7KsQIOi0ej2dvFbfOW4tmFkvH/YP8KJELo5AhP2+kEq1DpYA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/magic-string-linux-x64-musl": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-linux-x64-musl/-/magic-string-linux-x64-musl-0.3.4.tgz",
+      "integrity": "sha512-jN4h/7e2Ul8v3UK5IZu38NXLMdzVWhY4uEDlnwuUAhwRh26wBQ1/pLD97Uy/Z3dFNBQPcsv60XS9fOM1YDNT6w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/magic-string-win32-arm64-msvc": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-win32-arm64-msvc/-/magic-string-win32-arm64-msvc-0.3.4.tgz",
+      "integrity": "sha512-gMUyTRHLWpzX2ntJFCbW2Gnla9Y/WUmbkZuW5SBAo/Jo8QojHn76Y4PNgnoXdzcsV9b/45RBxurYKAfFg9WTyg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/magic-string-win32-ia32-msvc": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-win32-ia32-msvc/-/magic-string-win32-ia32-msvc-0.3.4.tgz",
+      "integrity": "sha512-QIMauMOvEHgL00K9np/c9CT/CRtLOz3mRTQqcZ9XGzSoAMrpxH71KSpDJrKl7h7Ro6TZ+hJ0C3T+JVuTCZNv4A==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/magic-string-win32-x64-msvc": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-win32-x64-msvc/-/magic-string-win32-x64-msvc-0.3.4.tgz",
+      "integrity": "sha512-V8FMSf828MzOI3P6/765MR7zHU6CUZqiyPhmAnwYoKFNxfv7oCviN/G6NcENeCdcYOvNgh5fYzaNLB96ndId5A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -5400,6 +5633,118 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
       "dev": true
+    },
+    "@napi-rs/magic-string": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/magic-string/-/magic-string-0.3.4.tgz",
+      "integrity": "sha512-DEWl/B99RQsyMT3F9bvrXuhL01/eIQp/dtNSE3G1jQ4mTGRcP4iHWxoPZ577WrbjUinrNgvRA5+08g8fkPgimQ==",
+      "dev": true,
+      "requires": {
+        "@napi-rs/magic-string-android-arm-eabi": "0.3.4",
+        "@napi-rs/magic-string-android-arm64": "0.3.4",
+        "@napi-rs/magic-string-darwin-arm64": "0.3.4",
+        "@napi-rs/magic-string-darwin-x64": "0.3.4",
+        "@napi-rs/magic-string-freebsd-x64": "0.3.4",
+        "@napi-rs/magic-string-linux-arm-gnueabihf": "0.3.4",
+        "@napi-rs/magic-string-linux-arm64-gnu": "0.3.4",
+        "@napi-rs/magic-string-linux-arm64-musl": "0.3.4",
+        "@napi-rs/magic-string-linux-x64-gnu": "0.3.4",
+        "@napi-rs/magic-string-linux-x64-musl": "0.3.4",
+        "@napi-rs/magic-string-win32-arm64-msvc": "0.3.4",
+        "@napi-rs/magic-string-win32-ia32-msvc": "0.3.4",
+        "@napi-rs/magic-string-win32-x64-msvc": "0.3.4"
+      }
+    },
+    "@napi-rs/magic-string-android-arm-eabi": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-android-arm-eabi/-/magic-string-android-arm-eabi-0.3.4.tgz",
+      "integrity": "sha512-sszAYxqtzzJ4FDerDNHcqL9NhqPhj8W4DNiOanXYy50mA5oojlRtaAFPiB5ZMrWDBM32v5Q30LrmxQ4eTtu2Dg==",
+      "dev": true,
+      "optional": true
+    },
+    "@napi-rs/magic-string-android-arm64": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-android-arm64/-/magic-string-android-arm64-0.3.4.tgz",
+      "integrity": "sha512-jdQ6HuO0X5rkX4MauTcWR4HWdgjakTOmmzqXg8L26+jOHVVG1LZE+Su5qvV4bP8vMb2h+vPE+JsnwqSmWymu3Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@napi-rs/magic-string-darwin-arm64": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-darwin-arm64/-/magic-string-darwin-arm64-0.3.4.tgz",
+      "integrity": "sha512-6NmMtvURce9/oq09XBZmuIeI6lPLGtEJ2ZPO/QzL3nLZa6wygiCnO/sFACKYNg5/73ET5HMMTeuogE1JI+r2Lw==",
+      "dev": true,
+      "optional": true
+    },
+    "@napi-rs/magic-string-darwin-x64": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-darwin-x64/-/magic-string-darwin-x64-0.3.4.tgz",
+      "integrity": "sha512-f9LmfMiUAKDOtl0meOuLYeVb6OERrgGzrTg1Tn3R3fTAShM2kxRbfAuPE9ljuXxIFzOv/uqRNLSl/LqCJwpREA==",
+      "dev": true,
+      "optional": true
+    },
+    "@napi-rs/magic-string-freebsd-x64": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-freebsd-x64/-/magic-string-freebsd-x64-0.3.4.tgz",
+      "integrity": "sha512-rqduQ4odiDK4QdM45xHWRTU4wtFIfpp8g8QGpz+3qqg7ivldDqbbNOrBaf6Oeu77uuEvWggnkyuChotfKgJdJQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@napi-rs/magic-string-linux-arm-gnueabihf": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-linux-arm-gnueabihf/-/magic-string-linux-arm-gnueabihf-0.3.4.tgz",
+      "integrity": "sha512-pVaJEdEpiPqIfq3M4+yMAATS7Z9muDcWYn8H7GFH1ygh8GwgLgKfy/n/lG2M6zp18Mwd0x7E2E/qg9GgCyUzoQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@napi-rs/magic-string-linux-arm64-gnu": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-linux-arm64-gnu/-/magic-string-linux-arm64-gnu-0.3.4.tgz",
+      "integrity": "sha512-9FwoAih/0tzEZx0BjYYIxWkSRMjonIn91RFM3q3MBs/evmThXUYXUqLNa1PPIkK1JoksswtDi48qWWLt8nGflQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@napi-rs/magic-string-linux-arm64-musl": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-linux-arm64-musl/-/magic-string-linux-arm64-musl-0.3.4.tgz",
+      "integrity": "sha512-wCR7R+WPOcAKmVQc1s6h6HwfwW1vL9pM8BjUY9Ljkdb8wt1LmZEmV2Sgfc1SfbRQzbyl+pKeufP6adRRQVzYDA==",
+      "dev": true,
+      "optional": true
+    },
+    "@napi-rs/magic-string-linux-x64-gnu": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-linux-x64-gnu/-/magic-string-linux-x64-gnu-0.3.4.tgz",
+      "integrity": "sha512-sbxFDpYnt5WFbxQ1xozwOvh5A7IftqSI0WnE9O7KsQIOi0ej2dvFbfOW4tmFkvH/YP8KJELo5AhP2+kEq1DpYA==",
+      "dev": true,
+      "optional": true
+    },
+    "@napi-rs/magic-string-linux-x64-musl": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-linux-x64-musl/-/magic-string-linux-x64-musl-0.3.4.tgz",
+      "integrity": "sha512-jN4h/7e2Ul8v3UK5IZu38NXLMdzVWhY4uEDlnwuUAhwRh26wBQ1/pLD97Uy/Z3dFNBQPcsv60XS9fOM1YDNT6w==",
+      "dev": true,
+      "optional": true
+    },
+    "@napi-rs/magic-string-win32-arm64-msvc": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-win32-arm64-msvc/-/magic-string-win32-arm64-msvc-0.3.4.tgz",
+      "integrity": "sha512-gMUyTRHLWpzX2ntJFCbW2Gnla9Y/WUmbkZuW5SBAo/Jo8QojHn76Y4PNgnoXdzcsV9b/45RBxurYKAfFg9WTyg==",
+      "dev": true,
+      "optional": true
+    },
+    "@napi-rs/magic-string-win32-ia32-msvc": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-win32-ia32-msvc/-/magic-string-win32-ia32-msvc-0.3.4.tgz",
+      "integrity": "sha512-QIMauMOvEHgL00K9np/c9CT/CRtLOz3mRTQqcZ9XGzSoAMrpxH71KSpDJrKl7h7Ro6TZ+hJ0C3T+JVuTCZNv4A==",
+      "dev": true,
+      "optional": true
+    },
+    "@napi-rs/magic-string-win32-x64-msvc": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-win32-x64-msvc/-/magic-string-win32-x64-msvc-0.3.4.tgz",
+      "integrity": "sha512-V8FMSf828MzOI3P6/765MR7zHU6CUZqiyPhmAnwYoKFNxfv7oCviN/G6NcENeCdcYOvNgh5fYzaNLB96ndId5A==",
+      "dev": true,
+      "optional": true
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,11 @@
       "license": "MIT",
       "dependencies": {
         "@fastify/deepmerge": "^1.3.0",
+        "@napi-rs/magic-string": "^0.3.4",
         "@rollup/pluginutils": "^4.2.1",
         "get-tsconfig": "^4.6.2"
       },
       "devDependencies": {
-        "@napi-rs/magic-string": "^0.3.4",
         "@rollup/plugin-commonjs": "^23.0.7",
         "@rollup/plugin-json": "^5.0.2",
         "@swc-node/register": "^1.6.6",
@@ -35,7 +35,6 @@
         "rollup": "^3.25.3",
         "rollup-plugin-dts": "^5.3.0",
         "rollup2": "npm:rollup@^2.79.1",
-        "ts-mocha": "^10.0.0",
         "typescript": "^5.1.6"
       },
       "engines": {
@@ -282,7 +281,6 @@
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/magic-string/-/magic-string-0.3.4.tgz",
       "integrity": "sha512-DEWl/B99RQsyMT3F9bvrXuhL01/eIQp/dtNSE3G1jQ4mTGRcP4iHWxoPZ577WrbjUinrNgvRA5+08g8fkPgimQ==",
-      "dev": true,
       "engines": {
         "node": ">= 10"
       },
@@ -309,7 +307,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -325,7 +322,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -341,7 +337,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -357,7 +352,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -373,7 +367,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -389,7 +382,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -405,7 +397,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -421,7 +412,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -437,7 +427,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -453,7 +442,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -469,7 +457,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -485,7 +472,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -501,7 +487,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -994,13 +979,6 @@
       "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
       "dev": true
     },
-    "node_modules/@types/json5": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
-      "dev": true,
-      "optional": true
-    },
     "node_modules/@types/mocha": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.1.tgz",
@@ -1378,15 +1356,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/assertion-error": {
@@ -3479,19 +3448,6 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
-    "node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.4.tgz",
@@ -3675,12 +3631,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
-    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -3733,12 +3683,6 @@
         "node": "*"
       }
     },
-    "node_modules/minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
-    },
     "node_modules/minipass": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.2.tgz",
@@ -3746,18 +3690,6 @@
       "dev": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/mocha": {
@@ -4885,16 +4817,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/strip-final-newline": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
@@ -5003,80 +4925,6 @@
       },
       "engines": {
         "node": ">=8.0"
-      }
-    },
-    "node_modules/ts-mocha": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/ts-mocha/-/ts-mocha-10.0.0.tgz",
-      "integrity": "sha512-VRfgDO+iiuJFlNB18tzOfypJ21xn2xbuZyDvJvqpTbWgkAgD17ONGr8t+Tl8rcBtOBdjXp5e/Rk+d39f7XBHRw==",
-      "dev": true,
-      "dependencies": {
-        "ts-node": "7.0.1"
-      },
-      "bin": {
-        "ts-mocha": "bin/ts-mocha"
-      },
-      "engines": {
-        "node": ">= 6.X.X"
-      },
-      "optionalDependencies": {
-        "tsconfig-paths": "^3.5.0"
-      },
-      "peerDependencies": {
-        "mocha": "^3.X.X || ^4.X.X || ^5.X.X || ^6.X.X || ^7.X.X || ^8.X.X || ^9.X.X || ^10.X.X"
-      }
-    },
-    "node_modules/ts-mocha/node_modules/diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/ts-mocha/node_modules/ts-node": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
-      "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
-      "dev": true,
-      "dependencies": {
-        "arrify": "^1.0.0",
-        "buffer-from": "^1.1.0",
-        "diff": "^3.1.0",
-        "make-error": "^1.1.1",
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "source-map-support": "^0.5.6",
-        "yn": "^2.0.0"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
-    "node_modules/ts-mocha/node_modules/yn": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
-      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/tsconfig-paths": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
-      "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "@types/json5": "^0.0.29",
-        "json5": "^1.0.1",
-        "minimist": "^1.2.6",
-        "strip-bom": "^3.0.0"
       }
     },
     "node_modules/tslib": {
@@ -5638,7 +5486,6 @@
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/magic-string/-/magic-string-0.3.4.tgz",
       "integrity": "sha512-DEWl/B99RQsyMT3F9bvrXuhL01/eIQp/dtNSE3G1jQ4mTGRcP4iHWxoPZ577WrbjUinrNgvRA5+08g8fkPgimQ==",
-      "dev": true,
       "requires": {
         "@napi-rs/magic-string-android-arm-eabi": "0.3.4",
         "@napi-rs/magic-string-android-arm64": "0.3.4",
@@ -5659,91 +5506,78 @@
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-android-arm-eabi/-/magic-string-android-arm-eabi-0.3.4.tgz",
       "integrity": "sha512-sszAYxqtzzJ4FDerDNHcqL9NhqPhj8W4DNiOanXYy50mA5oojlRtaAFPiB5ZMrWDBM32v5Q30LrmxQ4eTtu2Dg==",
-      "dev": true,
       "optional": true
     },
     "@napi-rs/magic-string-android-arm64": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-android-arm64/-/magic-string-android-arm64-0.3.4.tgz",
       "integrity": "sha512-jdQ6HuO0X5rkX4MauTcWR4HWdgjakTOmmzqXg8L26+jOHVVG1LZE+Su5qvV4bP8vMb2h+vPE+JsnwqSmWymu3Q==",
-      "dev": true,
       "optional": true
     },
     "@napi-rs/magic-string-darwin-arm64": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-darwin-arm64/-/magic-string-darwin-arm64-0.3.4.tgz",
       "integrity": "sha512-6NmMtvURce9/oq09XBZmuIeI6lPLGtEJ2ZPO/QzL3nLZa6wygiCnO/sFACKYNg5/73ET5HMMTeuogE1JI+r2Lw==",
-      "dev": true,
       "optional": true
     },
     "@napi-rs/magic-string-darwin-x64": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-darwin-x64/-/magic-string-darwin-x64-0.3.4.tgz",
       "integrity": "sha512-f9LmfMiUAKDOtl0meOuLYeVb6OERrgGzrTg1Tn3R3fTAShM2kxRbfAuPE9ljuXxIFzOv/uqRNLSl/LqCJwpREA==",
-      "dev": true,
       "optional": true
     },
     "@napi-rs/magic-string-freebsd-x64": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-freebsd-x64/-/magic-string-freebsd-x64-0.3.4.tgz",
       "integrity": "sha512-rqduQ4odiDK4QdM45xHWRTU4wtFIfpp8g8QGpz+3qqg7ivldDqbbNOrBaf6Oeu77uuEvWggnkyuChotfKgJdJQ==",
-      "dev": true,
       "optional": true
     },
     "@napi-rs/magic-string-linux-arm-gnueabihf": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-linux-arm-gnueabihf/-/magic-string-linux-arm-gnueabihf-0.3.4.tgz",
       "integrity": "sha512-pVaJEdEpiPqIfq3M4+yMAATS7Z9muDcWYn8H7GFH1ygh8GwgLgKfy/n/lG2M6zp18Mwd0x7E2E/qg9GgCyUzoQ==",
-      "dev": true,
       "optional": true
     },
     "@napi-rs/magic-string-linux-arm64-gnu": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-linux-arm64-gnu/-/magic-string-linux-arm64-gnu-0.3.4.tgz",
       "integrity": "sha512-9FwoAih/0tzEZx0BjYYIxWkSRMjonIn91RFM3q3MBs/evmThXUYXUqLNa1PPIkK1JoksswtDi48qWWLt8nGflQ==",
-      "dev": true,
       "optional": true
     },
     "@napi-rs/magic-string-linux-arm64-musl": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-linux-arm64-musl/-/magic-string-linux-arm64-musl-0.3.4.tgz",
       "integrity": "sha512-wCR7R+WPOcAKmVQc1s6h6HwfwW1vL9pM8BjUY9Ljkdb8wt1LmZEmV2Sgfc1SfbRQzbyl+pKeufP6adRRQVzYDA==",
-      "dev": true,
       "optional": true
     },
     "@napi-rs/magic-string-linux-x64-gnu": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-linux-x64-gnu/-/magic-string-linux-x64-gnu-0.3.4.tgz",
       "integrity": "sha512-sbxFDpYnt5WFbxQ1xozwOvh5A7IftqSI0WnE9O7KsQIOi0ej2dvFbfOW4tmFkvH/YP8KJELo5AhP2+kEq1DpYA==",
-      "dev": true,
       "optional": true
     },
     "@napi-rs/magic-string-linux-x64-musl": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-linux-x64-musl/-/magic-string-linux-x64-musl-0.3.4.tgz",
       "integrity": "sha512-jN4h/7e2Ul8v3UK5IZu38NXLMdzVWhY4uEDlnwuUAhwRh26wBQ1/pLD97Uy/Z3dFNBQPcsv60XS9fOM1YDNT6w==",
-      "dev": true,
       "optional": true
     },
     "@napi-rs/magic-string-win32-arm64-msvc": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-win32-arm64-msvc/-/magic-string-win32-arm64-msvc-0.3.4.tgz",
       "integrity": "sha512-gMUyTRHLWpzX2ntJFCbW2Gnla9Y/WUmbkZuW5SBAo/Jo8QojHn76Y4PNgnoXdzcsV9b/45RBxurYKAfFg9WTyg==",
-      "dev": true,
       "optional": true
     },
     "@napi-rs/magic-string-win32-ia32-msvc": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-win32-ia32-msvc/-/magic-string-win32-ia32-msvc-0.3.4.tgz",
       "integrity": "sha512-QIMauMOvEHgL00K9np/c9CT/CRtLOz3mRTQqcZ9XGzSoAMrpxH71KSpDJrKl7h7Ro6TZ+hJ0C3T+JVuTCZNv4A==",
-      "dev": true,
       "optional": true
     },
     "@napi-rs/magic-string-win32-x64-msvc": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/magic-string-win32-x64-msvc/-/magic-string-win32-x64-msvc-0.3.4.tgz",
       "integrity": "sha512-V8FMSf828MzOI3P6/765MR7zHU6CUZqiyPhmAnwYoKFNxfv7oCviN/G6NcENeCdcYOvNgh5fYzaNLB96ndId5A==",
-      "dev": true,
       "optional": true
     },
     "@nodelib/fs.scandir": {
@@ -6043,13 +5877,6 @@
       "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
       "dev": true
     },
-    "@types/json5": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
-      "dev": true,
-      "optional": true
-    },
     "@types/mocha": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.1.tgz",
@@ -6291,12 +6118,6 @@
         "es-abstract": "^1.20.4",
         "es-shim-unscopables": "^1.0.0"
       }
-    },
-    "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
     },
     "assertion-error": {
       "version": "1.1.0",
@@ -7830,16 +7651,6 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
-    "json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "minimist": "^1.2.0"
-      }
-    },
     "jsx-ast-utils": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.4.tgz",
@@ -7980,12 +7791,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.13"
       }
     },
-    "make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
-    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -8023,26 +7828,11 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
-    },
     "minipass": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.2.tgz",
       "integrity": "sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==",
       "dev": true
-    },
-    "mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5"
-      }
     },
     "mocha": {
       "version": "10.2.0",
@@ -8804,13 +8594,6 @@
         "ansi-regex": "^5.0.1"
       }
     },
-    "strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-      "dev": true,
-      "optional": true
-    },
     "strip-final-newline": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
@@ -8882,59 +8665,6 @@
       "dev": true,
       "requires": {
         "is-number": "^7.0.0"
-      }
-    },
-    "ts-mocha": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/ts-mocha/-/ts-mocha-10.0.0.tgz",
-      "integrity": "sha512-VRfgDO+iiuJFlNB18tzOfypJ21xn2xbuZyDvJvqpTbWgkAgD17ONGr8t+Tl8rcBtOBdjXp5e/Rk+d39f7XBHRw==",
-      "dev": true,
-      "requires": {
-        "ts-node": "7.0.1",
-        "tsconfig-paths": "^3.5.0"
-      },
-      "dependencies": {
-        "diff": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-          "dev": true
-        },
-        "ts-node": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
-          "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
-          "dev": true,
-          "requires": {
-            "arrify": "^1.0.0",
-            "buffer-from": "^1.1.0",
-            "diff": "^3.1.0",
-            "make-error": "^1.1.1",
-            "minimist": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "source-map-support": "^0.5.6",
-            "yn": "^2.0.0"
-          }
-        },
-        "yn": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
-          "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
-          "dev": true
-        }
-      }
-    },
-    "tsconfig-paths": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
-      "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "@types/json5": "^0.0.29",
-        "json5": "^1.0.1",
-        "minimist": "^1.2.6",
-        "strip-bom": "^3.0.0"
       }
     },
     "tslib": {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "scripts": {
     "prepublishOnly": "npm run clean && npm run test && npm run build",
     "clean": "rimraf ./dist ./test/temp",
-    "build": "node -r @swc-node/register tools/build.ts",
-    "test": "mocha -r @swc-node/register -p tsconfig.json test/index.ts"
+    "build": "SWC_NODE_PROJECT=./tsconfig.json node -r @swc-node/register tools/build.ts",
+    "test": "SWC_NODE_PROJECT=./tsconfig.json mocha -r @swc-node/register test/index.ts"
   },
   "repository": {
     "type": "git",
@@ -27,11 +27,11 @@
   "homepage": "https://github.com/SukkaW/rollup-plugin-swc#readme",
   "dependencies": {
     "@fastify/deepmerge": "^1.3.0",
+    "@napi-rs/magic-string": "^0.3.4",
     "@rollup/pluginutils": "^4.2.1",
     "get-tsconfig": "^4.6.2"
   },
   "devDependencies": {
-    "@napi-rs/magic-string": "^0.3.4",
     "@rollup/plugin-commonjs": "^23.0.7",
     "@rollup/plugin-json": "^5.0.2",
     "@swc-node/register": "^1.6.6",
@@ -52,13 +52,11 @@
     "rollup": "^3.25.3",
     "rollup-plugin-dts": "^5.3.0",
     "rollup2": "npm:rollup@^2.79.1",
-    "ts-mocha": "^10.0.0",
     "typescript": "^5.1.6"
   },
   "peerDependencies": {
     "@swc/core": ">=1.2.165",
-    "rollup": "^2.0.0 || ^3.0.0",
-    "@napi-rs/magic-string": "*"
+    "rollup": "^2.0.0 || ^3.0.0"
   },
   "engines": {
     "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "get-tsconfig": "^4.6.2"
   },
   "devDependencies": {
+    "@napi-rs/magic-string": "^0.3.4",
     "@rollup/plugin-commonjs": "^23.0.7",
     "@rollup/plugin-json": "^5.0.2",
     "@swc-node/register": "^1.6.6",
@@ -56,7 +57,8 @@
   },
   "peerDependencies": {
     "@swc/core": ">=1.2.165",
-    "rollup": "^2.0.0 || ^3.0.0"
+    "rollup": "^2.0.0 || ^3.0.0",
+    "@napi-rs/magic-string": "*"
   },
   "engines": {
     "node": ">=12"

--- a/src/directive.ts
+++ b/src/directive.ts
@@ -16,7 +16,7 @@ import { MagicString } from '@napi-rs/magic-string';
 
 const isNonNull = <T>(val: T | null | undefined): val is T => val != null;
 
-export function preserveUseDirectivePlugin(): Plugin {
+export function preserveUseDirective(): Plugin {
   const fileDirectivesMap = new Map<string, Set<string>>();
 
   return {

--- a/src/directive.ts
+++ b/src/directive.ts
@@ -1,0 +1,63 @@
+/**
+ * Originally created by huozhi @ GitHub <https://huozhi.im/>
+ * License: MIT
+ * This is from huozhi's amazing zero config bundler: https://github.com/huozhi/bunchee
+ *
+ * https://github.com/huozhi/bunchee/blob/23cbd6ebab992b886a207a531ec54dfa0877ab39/src/plugins/directive-plugin.ts
+ *
+ * Following changes are made:
+ *
+ * - Replace `magic-string` with `@napi-rs/magic-string`
+ * - Use a Map to track directives for each module, to support multiple entries input
+ */
+
+import type { Plugin } from 'rollup';
+import { MagicString } from '@napi-rs/magic-string';
+
+const isNonNull = <T>(val: T | null | undefined): val is T => val != null;
+
+export function preserveUseDirectivePlugin(): Plugin {
+  const fileDirectivesMap = new Map<string, Set<string>>();
+
+  return {
+    name: 'preserve-use-directive',
+
+    transform(code, id) {
+      const regex = /^(?:['"]use[^'"]+['"][^\n]*|#![^\n]*)/gm;
+      const directives = new Set<string>();
+
+      const replacedCode = code.replace(regex, (match) => {
+        // replace double quotes with single quotes
+        directives.add(match.replace(/["]/g, '\''));
+        return '';
+      });
+
+      if (directives.size) fileDirectivesMap.set(id, directives);
+
+      return {
+        code: replacedCode,
+        map: null
+      };
+    },
+
+    renderChunk(code, chunk, { sourcemap }) {
+      const outputDirectives = chunk.moduleIds
+        .map((id) => fileDirectivesMap.get(id))
+        .filter(isNonNull)
+        .reduce((acc, directives) => {
+          directives.forEach((directive) => acc.add(directive));
+          return acc;
+        }, new Set<string>());
+
+      if (outputDirectives.size === 0) return null;
+
+      const s = new MagicString(code);
+      s.prepend(`${[...outputDirectives].join('\n')}\n`);
+
+      return {
+        code: s.toString(),
+        map: sourcemap ? s.generateMap({ hires: true }).toMap() : null
+      };
+    }
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,12 @@ import type { Plugin as RollupPlugin } from 'rollup';
 import fs from 'fs';
 import { extname, resolve, dirname, join } from 'path';
 import { createFilter, type FilterPattern } from '@rollup/pluginutils';
+import type {
+  Options as SwcOptions,
+  JscTarget,
+  JsMinifyOptions
+} from '@swc/core';
 import {
-  type Options as SwcOptions,
-  type JscTarget,
-  type JsMinifyOptions,
   transform as swcTransform,
   minify as swcMinify
 } from '@swc/core';
@@ -196,3 +198,4 @@ function defineRollupSwcMinifyOption(option: JsMinifyOptions) {
 
 export default swc;
 export { swc, defineRollupSwcOption, minify, defineRollupSwcMinifyOption };
+export { preserveUseDirective } from './directive';

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,5 +1,7 @@
-import { getTsconfig, parseTsconfig, type TsConfigJson } from 'get-tsconfig';
+import { getTsconfig, parseTsconfig } from 'get-tsconfig';
 import path from 'path';
+
+import type { TsConfigJson } from 'get-tsconfig';
 
 const cache = new Map<string, TsConfigJson.CompilerOptions>();
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -3,7 +3,9 @@ import fs from 'fs';
 import { rollup } from 'rollup2';
 import { rollup as rollup3, type Plugin as RollupPlugin, type ExternalOption } from 'rollup';
 
-import { swc, type PluginOptions, minify } from '../src';
+import type { PluginOptions } from '../src';
+import { swc, minify } from '../src';
+
 import json from '@rollup/plugin-json';
 import commonjs from '@rollup/plugin-commonjs';
 import { tmpdir } from 'os';

--- a/tools/build.ts
+++ b/tools/build.ts
@@ -9,17 +9,12 @@ import pkg from '../package.json';
 const deps = Object.keys(pkg.dependencies);
 const peerDeps = Object.keys(pkg.peerDependencies);
 
-const entries = {
-  index: './src/index.ts',
-  directive: './src/directive.ts'
-};
-
 async function main() {
   const external = [...deps, ...peerDeps, ...builtinModules];
 
   async function build() {
     const bundle = await rollup({
-      input: entries,
+      input: './src/index.ts',
       external,
       plugins: [swc(defineRollupSwcOption({
         jsc: {
@@ -32,19 +27,19 @@ async function main() {
     });
 
     return Promise.all([
-      bundle.write({ dir: './dist/', entryFileNames: '[name].js', format: 'cjs', exports: 'named', interop: 'auto' }),
-      bundle.write({ dir: './dist/', entryFileNames: '[name].mjs', format: 'esm', exports: 'named', interop: 'auto' })
+      bundle.write({ file: './dist/index.js', format: 'cjs', exports: 'named', interop: 'auto' }),
+      bundle.write({ file: './dist/index.mjs', format: 'esm', exports: 'named', interop: 'auto' })
     ]);
   }
 
   async function createDtsFile() {
     const bundle = await rollup({
-      input: entries,
+      input: './src/index.ts',
       external,
       plugins: [dts()]
     });
 
-    return bundle.write({ dir: './dist/', entryFileNames: '[name].d.ts' });
+    return bundle.write({ file: './dist/index.d.ts' });
   }
 
   return Promise.all([build(), createDtsFile()]).then(() => console.log('build finished!'));

--- a/tools/build.ts
+++ b/tools/build.ts
@@ -9,12 +9,17 @@ import pkg from '../package.json';
 const deps = Object.keys(pkg.dependencies);
 const peerDeps = Object.keys(pkg.peerDependencies);
 
+const entries = {
+  index: './src/index.ts',
+  directive: './src/directive.ts'
+};
+
 async function main() {
   const external = [...deps, ...peerDeps, ...builtinModules];
 
   async function build() {
     const bundle = await rollup({
-      input: './src/index.ts',
+      input: entries,
       external,
       plugins: [swc(defineRollupSwcOption({
         jsc: {
@@ -27,19 +32,19 @@ async function main() {
     });
 
     return Promise.all([
-      bundle.write({ file: './dist/index.js', format: 'cjs', exports: 'named', interop: 'auto' }),
-      bundle.write({ file: './dist/index.mjs', format: 'esm', exports: 'named', interop: 'auto' })
+      bundle.write({ dir: './dist/', entryFileNames: '[name].js', format: 'cjs', exports: 'named', interop: 'auto' }),
+      bundle.write({ dir: './dist/', entryFileNames: '[name].mjs', format: 'esm', exports: 'named', interop: 'auto' })
     ]);
   }
 
   async function createDtsFile() {
     const bundle = await rollup({
-      input: './src/index.ts',
+      input: entries,
       external,
       plugins: [dts()]
     });
 
-    return bundle.write({ file: './dist/index.d.ts' });
+    return bundle.write({ dir: './dist/', entryFileNames: '[name].d.ts' });
   }
 
   return Promise.all([build(), createDtsFile()]).then(() => console.log('build finished!'));


### PR DESCRIPTION
Based on @huozhi's awesome work:

- https://github.com/huozhi/bunchee/blob/23cbd6ebab992b886a207a531ec54dfa0877ab39/src/plugins/directive-plugin.ts

The following changes are made:

- Replace `magic-string` with `@napi-rs/magic-string`
- Use a Map to track directives for each module, to support multiple entries input