### PR TITLE
fix: Pass correct option to swc

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -117,8 +117,7 @@ function swc(options: PluginOptions = {}): RollupPlugin {
           externalHelpers: tsconfigOptions.importHelpers,
           parser: {
             syntax: isTypeScript ? 'typescript' : 'ecmascript',
-            tsx: isTypeScript ? isTsx : undefined,
-            jsx: !isTypeScript ? isJsx : undefined,
+            [isTypeScript?'tsx':'jsx']: isTypeScript ? isTsx : isJsx,
             decorators: tsconfigOptions.experimentalDecorators
           },
           transform: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,7 +169,10 @@ function swc(options: PluginOptions = {}): RollupPlugin {
 
     renderChunk(code: string) {
       if (options.minify || options.jsc?.minify?.mangle || options.jsc?.minify?.compress) {
-        return swcMinify(code, options.jsc?.minify);
+        return swcMinify(code, {
+          ...options.jsc?.minify,
+          module: true
+        });
       }
 
       return null;


### PR DESCRIPTION
Parser options pass to `swc.transform` should be correct, otherwise it becomes `Syntax::Es(Default::default())`.
I don't know why serde behaves in this way, though.