### PR TITLE
fix(#63): handle tsconfig with only relative `baseUrl`

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -21,7 +21,7 @@ export const getOptions = (
     const compilerOptions = parseTsconfig(tsconfig).compilerOptions ?? {};
 
     const tsconfigDir = path.dirname(tsconfig);
-    if (compilerOptions.paths != null) {
+    if (compilerOptions.paths != null || compilerOptions.baseUrl != null) {
       compilerOptions.baseUrl = compilerOptions.baseUrl != null
         ? path.resolve(tsconfigDir, compilerOptions.baseUrl)
         : tsconfigDir;
@@ -42,7 +42,7 @@ export const getOptions = (
   }
 
   const compilerOptions = result?.config.compilerOptions ?? {};
-  if (compilerOptions.paths != null) {
+  if (compilerOptions.paths != null || compilerOptions.baseUrl != null) {
     if (result?.path) {
       const tsconfigDir = path.dirname(result.path);
       compilerOptions.baseUrl = compilerOptions.baseUrl != null

--- a/test/__snapshots__/index.ts.snap
+++ b/test/__snapshots__/index.ts.snap
@@ -402,6 +402,38 @@ ee.on(\\"test\\", function() {
 "
 `;
 
+exports[`rollup-plugin-swc3 swc (rollup 2) issue 63 - tsconfig baseUrl only + relative baseUrl 1`] = `
+"function _check_private_redeclaration(obj, privateCollection) {
+    if (privateCollection.has(obj)) {
+        throw new TypeError(\\"Cannot initialize the same private elements twice on an object\\");
+    }
+}
+function _class_call_check(instance, Constructor) {
+    if (!(instance instanceof Constructor)) {
+        throw new TypeError(\\"Cannot call a class as a function\\");
+    }
+}
+function _class_private_field_init(obj, privateMap, value) {
+    _check_private_redeclaration(obj, privateMap);
+    privateMap.set(obj, value);
+}
+function test(s) {
+    console.log(s);
+}
+test(\\"hello swc!\\");
+var _es2022Feature = /*#__PURE__*/ new WeakMap();
+var Test = function Test() {
+    _class_call_check(this, Test);
+    _class_private_field_init(this, _es2022Feature, {
+        writable: true,
+        value: true
+    });
+};
+
+export { Test };
+"
+`;
+
 exports[`rollup-plugin-swc3 swc (rollup 2) load json 1`] = `
 "var foo = true;
 var foo$1 = {
@@ -1026,6 +1058,38 @@ ee.on(\\"test\\", function() {
 "
 `;
 
+exports[`rollup-plugin-swc3 swc (rollup 3) issue 63 - tsconfig baseUrl only + relative baseUrl 1`] = `
+"function _check_private_redeclaration(obj, privateCollection) {
+    if (privateCollection.has(obj)) {
+        throw new TypeError(\\"Cannot initialize the same private elements twice on an object\\");
+    }
+}
+function _class_call_check(instance, Constructor) {
+    if (!(instance instanceof Constructor)) {
+        throw new TypeError(\\"Cannot call a class as a function\\");
+    }
+}
+function _class_private_field_init(obj, privateMap, value) {
+    _check_private_redeclaration(obj, privateMap);
+    privateMap.set(obj, value);
+}
+function test(s) {
+    console.log(s);
+}
+test(\\"hello swc!\\");
+var _es2022Feature = /*#__PURE__*/ new WeakMap();
+var Test = function Test() {
+    _class_call_check(this, Test);
+    _class_private_field_init(this, _es2022Feature, {
+        writable: true,
+        value: true
+    });
+};
+
+export { Test };
+"
+`;
+
 exports[`rollup-plugin-swc3 swc (rollup 3) load json 1`] = `
 "var foo = true;
 var foo$1 = {
@@ -1647,6 +1711,38 @@ var ee = new EventEmitter();
 ee.on(\\"test\\", function() {
     console.log(\\"test\\");
 });
+"
+`;
+
+exports[`rollup-plugin-swc3 swc (rollup 4) issue 63 - tsconfig baseUrl only + relative baseUrl 1`] = `
+"function _check_private_redeclaration(obj, privateCollection) {
+    if (privateCollection.has(obj)) {
+        throw new TypeError(\\"Cannot initialize the same private elements twice on an object\\");
+    }
+}
+function _class_call_check(instance, Constructor) {
+    if (!(instance instanceof Constructor)) {
+        throw new TypeError(\\"Cannot call a class as a function\\");
+    }
+}
+function _class_private_field_init(obj, privateMap, value) {
+    _check_private_redeclaration(obj, privateMap);
+    privateMap.set(obj, value);
+}
+function test(s) {
+    console.log(s);
+}
+test(\\"hello swc!\\");
+var _es2022Feature = /*#__PURE__*/ new WeakMap();
+var Test = function Test() {
+    _class_call_check(this, Test);
+    _class_private_field_init(this, _es2022Feature, {
+        writable: true,
+        value: true
+    });
+};
+
+export { Test };
 "
 `;
 

--- a/test/fixtures/tsconfig-base-url-only-relative-issue-63/src/index.ts
+++ b/test/fixtures/tsconfig-base-url-only-relative-issue-63/src/index.ts
@@ -1,0 +1,9 @@
+function test(s: string) {
+  console.log(s)
+}
+
+test('hello swc!')
+
+export class Test {
+  #es2022Feature = true
+}

--- a/test/fixtures/tsconfig-base-url-only-relative-issue-63/tsconfig.json
+++ b/test/fixtures/tsconfig-base-url-only-relative-issue-63/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./src",
+    "module": "ES2022",
+    "target": "ES2017"
+  },
+  "include": ["./index.ts"],
+}

--- a/test/index.ts
+++ b/test/index.ts
@@ -362,6 +362,16 @@ const tests = (rollupImpl: typeof rollup2 | typeof rollup3 | typeof rollup4, iso
       { input: './index.ts', dir, otherRollupPlugins: [nodeResolve(), commonjs()] }
     ))[0].code.should.matchSnapshot();
   });
+
+  it('issue 63 - tsconfig baseUrl only + relative baseUrl', async () => {
+    const dir = await fixture('tsconfig-base-url-only-relative-issue-63');
+
+    (await build(
+      rollupImpl,
+      { tsconfig: false },
+      { input: './src/index.ts', dir, otherRollupPlugins: [nodeResolve(), commonjs()] }
+    ))[0].code.should.matchSnapshot();
+  });
 };
 
 describe('rollup-plugin-swc3', () => {


### PR DESCRIPTION
Fixes #63.

Previously, the `rollup-plugin-swc3` only handled relative `baseUrl` when `paths` existed. The PR fixes that.