### PR TITLE
fix: should respect legacy decorators

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "prepublishOnly": "npm run clean && npm run test && npm run build",
     "clean": "rimraf ./dist ./test/temp",
     "build": "SWC_NODE_PROJECT=./tsconfig.json node -r @swc-node/register tools/build.ts",
-    "test": "SWC_NODE_PROJECT=./tsconfig.json mocha -r @swc-node/register test/index.ts",
+    "test": "SWC_NODE_PROJECT=./tsconfig.json mocha -r @swc-node/register test/index.ts --update",
     "lint": "eslint --format sukka ."
   },
   "author": "",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "prepublishOnly": "npm run clean && npm run test && npm run build",
     "clean": "rimraf ./dist ./test/temp",
     "build": "SWC_NODE_PROJECT=./tsconfig.json node -r @swc-node/register tools/build.ts",
-    "test": "SWC_NODE_PROJECT=./tsconfig.json mocha -r @swc-node/register test/index.ts --update",
+    "test": "SWC_NODE_PROJECT=./tsconfig.json mocha -r @swc-node/register test/index.ts",
     "lint": "eslint --format sukka ."
   },
   "author": "",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import {
 } from '@swc/core';
 import createDeepMerge from '@fastify/deepmerge';
 
-import { getOptions, getEnableExperimentalDecorators } from './options';
+import { getOptions, checkIsLegacyTypeScript } from './options';
 
 import type { Plugin as VitePlugin } from 'vite';
 
@@ -67,7 +67,7 @@ function swc(options: PluginOptions = {}): RollupPlugin {
     return null;
   };
 
-  const enableExperimentalDecorators = getEnableExperimentalDecorators();
+  const isLegacyTypeScript = checkIsLegacyTypeScript();
 
   return {
     name: 'swc',
@@ -127,7 +127,7 @@ function swc(options: PluginOptions = {}): RollupPlugin {
           parser: {
             syntax: isTypeScript ? 'typescript' : 'ecmascript',
             [isTypeScript ? 'tsx' : 'jsx']: isTypeScript ? isTsx : isJsx,
-            decorators: enableExperimentalDecorators || tsconfigOptions.experimentalDecorators
+            decorators: !isLegacyTypeScript || tsconfigOptions.experimentalDecorators
           },
           transform: {
             decoratorMetadata: tsconfigOptions.emitDecoratorMetadata,
@@ -140,7 +140,7 @@ function swc(options: PluginOptions = {}): RollupPlugin {
               pragmaFrag: tsconfigOptions.jsxFragmentFactory,
               development: tsconfigOptions.jsx === 'react-jsxdev' ? true : undefined
             },
-            decoratorVersion: enableExperimentalDecorators ? '2022-03' : '2021-12'
+            decoratorVersion: isLegacyTypeScript ? '2021-12' : (tsconfigOptions.experimentalDecorators ? '2021-12' : '2022-03')
           },
           target: tsconfigOptions.target?.toLowerCase() as JscTarget | undefined,
           baseUrl: tsconfigOptions.baseUrl,

--- a/src/options.ts
+++ b/src/options.ts
@@ -65,7 +65,7 @@ export const checkIsLegacyTypeScript = () => {
     const tsPath = resolve('typescript/package.json', import.meta.url);
     const { version } = JSON.parse(fs.readFileSync(fileURLToPath(tsPath), 'utf-8'));
     const [major] = version.split('.');
-    // Only check experimental decorators for TypeScript 5+
+    // typescript 5+ enable experimentalDecorators by default so we think it's not legacy
     return +major < 5;
   } catch {
     return false;

--- a/src/options.ts
+++ b/src/options.ts
@@ -59,14 +59,14 @@ export const getOptions = (
   return compilerOptions;
 };
 
-export const getEnableExperimentalDecorators = () => {
+export const checkIsLegacyTypeScript = () => {
   try {
     // @ts-expect-error -- It's required to using 'import.mtea.url' but i don't want to change the tsconfig.
     const tsPath = resolve('typescript/package.json', import.meta.url);
     const { version } = JSON.parse(fs.readFileSync(fileURLToPath(tsPath), 'utf-8'));
     const [major] = version.split('.');
     // Only check experimental decorators for TypeScript 5+
-    return +major >= 5;
+    return +major < 5;
   } catch {
     return false;
   }

--- a/test/__snapshots__/index.ts.snap
+++ b/test/__snapshots__/index.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`rollup-plugin-swc3 swc (rollup 2) detect  decorator for typescript5 1`] = `
+exports[`rollup-plugin-swc3 swc (rollup 2) detect decorator for typescript5 1`] = `
 "function _array_like_to_array(arr, len) {
     if (len == null || len > arr.length) len = arr.length;
     for(var i = 0, arr2 = new Array(len); i < len; i++)arr2[i] = arr[i];
@@ -13,6 +13,20 @@ function _class_call_check(instance, Constructor) {
     if (!(instance instanceof Constructor)) {
         throw new TypeError(\\"Cannot call a class as a function\\");
     }
+}
+function _defineProperties(target, props) {
+    for(var i = 0; i < props.length; i++){
+        var descriptor = props[i];
+        descriptor.enumerable = descriptor.enumerable || false;
+        descriptor.configurable = true;
+        if (\\"value\\" in descriptor) descriptor.writable = true;
+        Object.defineProperty(target, descriptor.key, descriptor);
+    }
+}
+function _create_class(Constructor, protoProps, staticProps) {
+    if (protoProps) _defineProperties(Constructor.prototype, protoProps);
+    if (staticProps) _defineProperties(Constructor, staticProps);
+    return Constructor;
 }
 function _define_property(obj, key, value) {
     if (key in obj) {
@@ -437,23 +451,97 @@ function applyDecs2203RFactory() {
 function _apply_decs_2203_r(targetClass, memberDecs, classDecs, parentClass) {
     return (_apply_decs_2203_r = applyDecs2203RFactory())(targetClass, memberDecs, classDecs, parentClass);
 }
-var // @ts-expect-error
-_init_name;
-var printMemberName = function(target, memberName) {
-    console.log(memberName);
-};
-var Person = function Person() {
-    _class_call_check(this, Person);
-    _define_property(this, \\"name\\", _init_name(this, \\"Jon\\"));
-};
+var _initProto;
+function trace(value, param) {
+    var kind = param.kind; param.name;
+    if (kind === 'method') {
+        return function() {
+            for(var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++){
+                args[_key] = arguments[_key];
+            }
+            console.log('trace');
+            return value.apply(this, args);
+        };
+    }
+}
+var People = /*#__PURE__*/ function() {
+    function People() {
+        _class_call_check(this, People);
+        _define_property(this, \\"xzy\\", void 0);
+        _initProto(this);
+        this.xzy = 'xzy';
+    }
+    _create_class(People, [
+        {
+            key: \\"test\\",
+            value: function test() {
+                return this.xzy;
+            }
+        }
+    ]);
+    return People;
+}();
 var ref, ref1;
-ref = _apply_decs_2203_r(Person, [
+ref = _apply_decs_2203_r(People, [
     [
-        printMemberName,
-        0,
-        \\"name\\"
+        trace,
+        2,
+        \\"test\\"
     ]
-], []), ref1 = _sliced_to_array(ref.e, 1), _init_name = ref1[0];
+], []), ref1 = _sliced_to_array(ref.e, 1), _initProto = ref1[0];
+var p = new People();
+p.test();
+"
+`;
+
+exports[`rollup-plugin-swc3 swc (rollup 2) detect legacy decorator for typescript5 1`] = `
+"function _define_property(obj, key, value) {
+    if (key in obj) {
+        Object.defineProperty(obj, key, {
+            value: value,
+            enumerable: true,
+            configurable: true,
+            writable: true
+        });
+    } else {
+        obj[key] = value;
+    }
+    return obj;
+}
+function _ts_decorate(decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === \\"object\\" && typeof Reflect.decorate === \\"function\\") r = Reflect.decorate(decorators, target, key, desc);
+    else for(var i = decorators.length - 1; i >= 0; i--)if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+}
+function _ts_metadata(k, v) {
+    if (typeof Reflect === \\"object\\" && typeof Reflect.metadata === \\"function\\") return Reflect.metadata(k, v);
+}
+function trace(_target, _name, descriptor) {
+    const original = descriptor.value;
+    descriptor.value = function() {
+        console.log('trace');
+        return original.call(this);
+    };
+    return descriptor;
+}
+class People {
+    test() {
+        return this.xzy;
+    }
+    constructor(){
+        _define_property(this, \\"xzy\\", void 0);
+        this.xzy = 'xzy';
+    }
+}
+_ts_decorate([
+    trace,
+    _ts_metadata(\\"design:type\\", Function),
+    _ts_metadata(\\"design:paramtypes\\", []),
+    _ts_metadata(\\"design:returntype\\", void 0)
+], People.prototype, \\"test\\", null);
+const p = new People();
+p.test();
 "
 `;
 
@@ -510,352 +598,345 @@ var eventemitter3 = {exports: {}};
 
 eventemitter3.exports;
 
-var hasRequiredEventemitter3;
+(function (module) {
 
-function requireEventemitter3 () {
-	if (hasRequiredEventemitter3) return eventemitter3.exports;
-	hasRequiredEventemitter3 = 1;
-	(function (module) {
+	var has = Object.prototype.hasOwnProperty
+	  , prefix = '~';
 
-		var has = Object.prototype.hasOwnProperty
-		  , prefix = '~';
+	/**
+	 * Constructor to create a storage for our \`EE\` objects.
+	 * An \`Events\` instance is a plain object whose properties are event names.
+	 *
+	 * @constructor
+	 * @private
+	 */
+	function Events() {}
 
-		/**
-		 * Constructor to create a storage for our \`EE\` objects.
-		 * An \`Events\` instance is a plain object whose properties are event names.
-		 *
-		 * @constructor
-		 * @private
-		 */
-		function Events() {}
+	//
+	// We try to not inherit from \`Object.prototype\`. In some engines creating an
+	// instance in this way is faster than calling \`Object.create(null)\` directly.
+	// If \`Object.create(null)\` is not supported we prefix the event names with a
+	// character to make sure that the built-in object properties are not
+	// overridden or used as an attack vector.
+	//
+	if (Object.create) {
+	  Events.prototype = Object.create(null);
 
-		//
-		// We try to not inherit from \`Object.prototype\`. In some engines creating an
-		// instance in this way is faster than calling \`Object.create(null)\` directly.
-		// If \`Object.create(null)\` is not supported we prefix the event names with a
-		// character to make sure that the built-in object properties are not
-		// overridden or used as an attack vector.
-		//
-		if (Object.create) {
-		  Events.prototype = Object.create(null);
+	  //
+	  // This hack is needed because the \`__proto__\` property is still inherited in
+	  // some old browsers like Android 4, iPhone 5.1, Opera 11 and Safari 5.
+	  //
+	  if (!new Events().__proto__) prefix = false;
+	}
 
-		  //
-		  // This hack is needed because the \`__proto__\` property is still inherited in
-		  // some old browsers like Android 4, iPhone 5.1, Opera 11 and Safari 5.
-		  //
-		  if (!new Events().__proto__) prefix = false;
-		}
+	/**
+	 * Representation of a single event listener.
+	 *
+	 * @param {Function} fn The listener function.
+	 * @param {*} context The context to invoke the listener with.
+	 * @param {Boolean} [once=false] Specify if the listener is a one-time listener.
+	 * @constructor
+	 * @private
+	 */
+	function EE(fn, context, once) {
+	  this.fn = fn;
+	  this.context = context;
+	  this.once = once || false;
+	}
 
-		/**
-		 * Representation of a single event listener.
-		 *
-		 * @param {Function} fn The listener function.
-		 * @param {*} context The context to invoke the listener with.
-		 * @param {Boolean} [once=false] Specify if the listener is a one-time listener.
-		 * @constructor
-		 * @private
-		 */
-		function EE(fn, context, once) {
-		  this.fn = fn;
-		  this.context = context;
-		  this.once = once || false;
-		}
+	/**
+	 * Add a listener for a given event.
+	 *
+	 * @param {EventEmitter} emitter Reference to the \`EventEmitter\` instance.
+	 * @param {(String|Symbol)} event The event name.
+	 * @param {Function} fn The listener function.
+	 * @param {*} context The context to invoke the listener with.
+	 * @param {Boolean} once Specify if the listener is a one-time listener.
+	 * @returns {EventEmitter}
+	 * @private
+	 */
+	function addListener(emitter, event, fn, context, once) {
+	  if (typeof fn !== 'function') {
+	    throw new TypeError('The listener must be a function');
+	  }
 
-		/**
-		 * Add a listener for a given event.
-		 *
-		 * @param {EventEmitter} emitter Reference to the \`EventEmitter\` instance.
-		 * @param {(String|Symbol)} event The event name.
-		 * @param {Function} fn The listener function.
-		 * @param {*} context The context to invoke the listener with.
-		 * @param {Boolean} once Specify if the listener is a one-time listener.
-		 * @returns {EventEmitter}
-		 * @private
-		 */
-		function addListener(emitter, event, fn, context, once) {
-		  if (typeof fn !== 'function') {
-		    throw new TypeError('The listener must be a function');
-		  }
+	  var listener = new EE(fn, context || emitter, once)
+	    , evt = prefix ? prefix + event : event;
 
-		  var listener = new EE(fn, context || emitter, once)
-		    , evt = prefix ? prefix + event : event;
+	  if (!emitter._events[evt]) emitter._events[evt] = listener, emitter._eventsCount++;
+	  else if (!emitter._events[evt].fn) emitter._events[evt].push(listener);
+	  else emitter._events[evt] = [emitter._events[evt], listener];
 
-		  if (!emitter._events[evt]) emitter._events[evt] = listener, emitter._eventsCount++;
-		  else if (!emitter._events[evt].fn) emitter._events[evt].push(listener);
-		  else emitter._events[evt] = [emitter._events[evt], listener];
+	  return emitter;
+	}
 
-		  return emitter;
-		}
+	/**
+	 * Clear event by name.
+	 *
+	 * @param {EventEmitter} emitter Reference to the \`EventEmitter\` instance.
+	 * @param {(String|Symbol)} evt The Event name.
+	 * @private
+	 */
+	function clearEvent(emitter, evt) {
+	  if (--emitter._eventsCount === 0) emitter._events = new Events();
+	  else delete emitter._events[evt];
+	}
 
-		/**
-		 * Clear event by name.
-		 *
-		 * @param {EventEmitter} emitter Reference to the \`EventEmitter\` instance.
-		 * @param {(String|Symbol)} evt The Event name.
-		 * @private
-		 */
-		function clearEvent(emitter, evt) {
-		  if (--emitter._eventsCount === 0) emitter._events = new Events();
-		  else delete emitter._events[evt];
-		}
+	/**
+	 * Minimal \`EventEmitter\` interface that is molded against the Node.js
+	 * \`EventEmitter\` interface.
+	 *
+	 * @constructor
+	 * @public
+	 */
+	function EventEmitter() {
+	  this._events = new Events();
+	  this._eventsCount = 0;
+	}
 
-		/**
-		 * Minimal \`EventEmitter\` interface that is molded against the Node.js
-		 * \`EventEmitter\` interface.
-		 *
-		 * @constructor
-		 * @public
-		 */
-		function EventEmitter() {
-		  this._events = new Events();
-		  this._eventsCount = 0;
-		}
+	/**
+	 * Return an array listing the events for which the emitter has registered
+	 * listeners.
+	 *
+	 * @returns {Array}
+	 * @public
+	 */
+	EventEmitter.prototype.eventNames = function eventNames() {
+	  var names = []
+	    , events
+	    , name;
 
-		/**
-		 * Return an array listing the events for which the emitter has registered
-		 * listeners.
-		 *
-		 * @returns {Array}
-		 * @public
-		 */
-		EventEmitter.prototype.eventNames = function eventNames() {
-		  var names = []
-		    , events
-		    , name;
+	  if (this._eventsCount === 0) return names;
 
-		  if (this._eventsCount === 0) return names;
+	  for (name in (events = this._events)) {
+	    if (has.call(events, name)) names.push(prefix ? name.slice(1) : name);
+	  }
 
-		  for (name in (events = this._events)) {
-		    if (has.call(events, name)) names.push(prefix ? name.slice(1) : name);
-		  }
+	  if (Object.getOwnPropertySymbols) {
+	    return names.concat(Object.getOwnPropertySymbols(events));
+	  }
 
-		  if (Object.getOwnPropertySymbols) {
-		    return names.concat(Object.getOwnPropertySymbols(events));
-		  }
+	  return names;
+	};
 
-		  return names;
-		};
+	/**
+	 * Return the listeners registered for a given event.
+	 *
+	 * @param {(String|Symbol)} event The event name.
+	 * @returns {Array} The registered listeners.
+	 * @public
+	 */
+	EventEmitter.prototype.listeners = function listeners(event) {
+	  var evt = prefix ? prefix + event : event
+	    , handlers = this._events[evt];
 
-		/**
-		 * Return the listeners registered for a given event.
-		 *
-		 * @param {(String|Symbol)} event The event name.
-		 * @returns {Array} The registered listeners.
-		 * @public
-		 */
-		EventEmitter.prototype.listeners = function listeners(event) {
-		  var evt = prefix ? prefix + event : event
-		    , handlers = this._events[evt];
+	  if (!handlers) return [];
+	  if (handlers.fn) return [handlers.fn];
 
-		  if (!handlers) return [];
-		  if (handlers.fn) return [handlers.fn];
+	  for (var i = 0, l = handlers.length, ee = new Array(l); i < l; i++) {
+	    ee[i] = handlers[i].fn;
+	  }
 
-		  for (var i = 0, l = handlers.length, ee = new Array(l); i < l; i++) {
-		    ee[i] = handlers[i].fn;
-		  }
+	  return ee;
+	};
 
-		  return ee;
-		};
+	/**
+	 * Return the number of listeners listening to a given event.
+	 *
+	 * @param {(String|Symbol)} event The event name.
+	 * @returns {Number} The number of listeners.
+	 * @public
+	 */
+	EventEmitter.prototype.listenerCount = function listenerCount(event) {
+	  var evt = prefix ? prefix + event : event
+	    , listeners = this._events[evt];
 
-		/**
-		 * Return the number of listeners listening to a given event.
-		 *
-		 * @param {(String|Symbol)} event The event name.
-		 * @returns {Number} The number of listeners.
-		 * @public
-		 */
-		EventEmitter.prototype.listenerCount = function listenerCount(event) {
-		  var evt = prefix ? prefix + event : event
-		    , listeners = this._events[evt];
+	  if (!listeners) return 0;
+	  if (listeners.fn) return 1;
+	  return listeners.length;
+	};
 
-		  if (!listeners) return 0;
-		  if (listeners.fn) return 1;
-		  return listeners.length;
-		};
+	/**
+	 * Calls each of the listeners registered for a given event.
+	 *
+	 * @param {(String|Symbol)} event The event name.
+	 * @returns {Boolean} \`true\` if the event had listeners, else \`false\`.
+	 * @public
+	 */
+	EventEmitter.prototype.emit = function emit(event, a1, a2, a3, a4, a5) {
+	  var evt = prefix ? prefix + event : event;
 
-		/**
-		 * Calls each of the listeners registered for a given event.
-		 *
-		 * @param {(String|Symbol)} event The event name.
-		 * @returns {Boolean} \`true\` if the event had listeners, else \`false\`.
-		 * @public
-		 */
-		EventEmitter.prototype.emit = function emit(event, a1, a2, a3, a4, a5) {
-		  var evt = prefix ? prefix + event : event;
+	  if (!this._events[evt]) return false;
 
-		  if (!this._events[evt]) return false;
+	  var listeners = this._events[evt]
+	    , len = arguments.length
+	    , args
+	    , i;
 
-		  var listeners = this._events[evt]
-		    , len = arguments.length
-		    , args
-		    , i;
+	  if (listeners.fn) {
+	    if (listeners.once) this.removeListener(event, listeners.fn, undefined, true);
 
-		  if (listeners.fn) {
-		    if (listeners.once) this.removeListener(event, listeners.fn, undefined, true);
+	    switch (len) {
+	      case 1: return listeners.fn.call(listeners.context), true;
+	      case 2: return listeners.fn.call(listeners.context, a1), true;
+	      case 3: return listeners.fn.call(listeners.context, a1, a2), true;
+	      case 4: return listeners.fn.call(listeners.context, a1, a2, a3), true;
+	      case 5: return listeners.fn.call(listeners.context, a1, a2, a3, a4), true;
+	      case 6: return listeners.fn.call(listeners.context, a1, a2, a3, a4, a5), true;
+	    }
 
-		    switch (len) {
-		      case 1: return listeners.fn.call(listeners.context), true;
-		      case 2: return listeners.fn.call(listeners.context, a1), true;
-		      case 3: return listeners.fn.call(listeners.context, a1, a2), true;
-		      case 4: return listeners.fn.call(listeners.context, a1, a2, a3), true;
-		      case 5: return listeners.fn.call(listeners.context, a1, a2, a3, a4), true;
-		      case 6: return listeners.fn.call(listeners.context, a1, a2, a3, a4, a5), true;
-		    }
+	    for (i = 1, args = new Array(len -1); i < len; i++) {
+	      args[i - 1] = arguments[i];
+	    }
 
-		    for (i = 1, args = new Array(len -1); i < len; i++) {
-		      args[i - 1] = arguments[i];
-		    }
+	    listeners.fn.apply(listeners.context, args);
+	  } else {
+	    var length = listeners.length
+	      , j;
 
-		    listeners.fn.apply(listeners.context, args);
-		  } else {
-		    var length = listeners.length
-		      , j;
+	    for (i = 0; i < length; i++) {
+	      if (listeners[i].once) this.removeListener(event, listeners[i].fn, undefined, true);
 
-		    for (i = 0; i < length; i++) {
-		      if (listeners[i].once) this.removeListener(event, listeners[i].fn, undefined, true);
+	      switch (len) {
+	        case 1: listeners[i].fn.call(listeners[i].context); break;
+	        case 2: listeners[i].fn.call(listeners[i].context, a1); break;
+	        case 3: listeners[i].fn.call(listeners[i].context, a1, a2); break;
+	        case 4: listeners[i].fn.call(listeners[i].context, a1, a2, a3); break;
+	        default:
+	          if (!args) for (j = 1, args = new Array(len -1); j < len; j++) {
+	            args[j - 1] = arguments[j];
+	          }
 
-		      switch (len) {
-		        case 1: listeners[i].fn.call(listeners[i].context); break;
-		        case 2: listeners[i].fn.call(listeners[i].context, a1); break;
-		        case 3: listeners[i].fn.call(listeners[i].context, a1, a2); break;
-		        case 4: listeners[i].fn.call(listeners[i].context, a1, a2, a3); break;
-		        default:
-		          if (!args) for (j = 1, args = new Array(len -1); j < len; j++) {
-		            args[j - 1] = arguments[j];
-		          }
+	          listeners[i].fn.apply(listeners[i].context, args);
+	      }
+	    }
+	  }
 
-		          listeners[i].fn.apply(listeners[i].context, args);
-		      }
-		    }
-		  }
+	  return true;
+	};
 
-		  return true;
-		};
+	/**
+	 * Add a listener for a given event.
+	 *
+	 * @param {(String|Symbol)} event The event name.
+	 * @param {Function} fn The listener function.
+	 * @param {*} [context=this] The context to invoke the listener with.
+	 * @returns {EventEmitter} \`this\`.
+	 * @public
+	 */
+	EventEmitter.prototype.on = function on(event, fn, context) {
+	  return addListener(this, event, fn, context, false);
+	};
 
-		/**
-		 * Add a listener for a given event.
-		 *
-		 * @param {(String|Symbol)} event The event name.
-		 * @param {Function} fn The listener function.
-		 * @param {*} [context=this] The context to invoke the listener with.
-		 * @returns {EventEmitter} \`this\`.
-		 * @public
-		 */
-		EventEmitter.prototype.on = function on(event, fn, context) {
-		  return addListener(this, event, fn, context, false);
-		};
+	/**
+	 * Add a one-time listener for a given event.
+	 *
+	 * @param {(String|Symbol)} event The event name.
+	 * @param {Function} fn The listener function.
+	 * @param {*} [context=this] The context to invoke the listener with.
+	 * @returns {EventEmitter} \`this\`.
+	 * @public
+	 */
+	EventEmitter.prototype.once = function once(event, fn, context) {
+	  return addListener(this, event, fn, context, true);
+	};
 
-		/**
-		 * Add a one-time listener for a given event.
-		 *
-		 * @param {(String|Symbol)} event The event name.
-		 * @param {Function} fn The listener function.
-		 * @param {*} [context=this] The context to invoke the listener with.
-		 * @returns {EventEmitter} \`this\`.
-		 * @public
-		 */
-		EventEmitter.prototype.once = function once(event, fn, context) {
-		  return addListener(this, event, fn, context, true);
-		};
+	/**
+	 * Remove the listeners of a given event.
+	 *
+	 * @param {(String|Symbol)} event The event name.
+	 * @param {Function} fn Only remove the listeners that match this function.
+	 * @param {*} context Only remove the listeners that have this context.
+	 * @param {Boolean} once Only remove one-time listeners.
+	 * @returns {EventEmitter} \`this\`.
+	 * @public
+	 */
+	EventEmitter.prototype.removeListener = function removeListener(event, fn, context, once) {
+	  var evt = prefix ? prefix + event : event;
 
-		/**
-		 * Remove the listeners of a given event.
-		 *
-		 * @param {(String|Symbol)} event The event name.
-		 * @param {Function} fn Only remove the listeners that match this function.
-		 * @param {*} context Only remove the listeners that have this context.
-		 * @param {Boolean} once Only remove one-time listeners.
-		 * @returns {EventEmitter} \`this\`.
-		 * @public
-		 */
-		EventEmitter.prototype.removeListener = function removeListener(event, fn, context, once) {
-		  var evt = prefix ? prefix + event : event;
+	  if (!this._events[evt]) return this;
+	  if (!fn) {
+	    clearEvent(this, evt);
+	    return this;
+	  }
 
-		  if (!this._events[evt]) return this;
-		  if (!fn) {
-		    clearEvent(this, evt);
-		    return this;
-		  }
+	  var listeners = this._events[evt];
 
-		  var listeners = this._events[evt];
+	  if (listeners.fn) {
+	    if (
+	      listeners.fn === fn &&
+	      (!once || listeners.once) &&
+	      (!context || listeners.context === context)
+	    ) {
+	      clearEvent(this, evt);
+	    }
+	  } else {
+	    for (var i = 0, events = [], length = listeners.length; i < length; i++) {
+	      if (
+	        listeners[i].fn !== fn ||
+	        (once && !listeners[i].once) ||
+	        (context && listeners[i].context !== context)
+	      ) {
+	        events.push(listeners[i]);
+	      }
+	    }
 
-		  if (listeners.fn) {
-		    if (
-		      listeners.fn === fn &&
-		      (!once || listeners.once) &&
-		      (!context || listeners.context === context)
-		    ) {
-		      clearEvent(this, evt);
-		    }
-		  } else {
-		    for (var i = 0, events = [], length = listeners.length; i < length; i++) {
-		      if (
-		        listeners[i].fn !== fn ||
-		        (once && !listeners[i].once) ||
-		        (context && listeners[i].context !== context)
-		      ) {
-		        events.push(listeners[i]);
-		      }
-		    }
+	    //
+	    // Reset the array, or remove it completely if we have no more listeners.
+	    //
+	    if (events.length) this._events[evt] = events.length === 1 ? events[0] : events;
+	    else clearEvent(this, evt);
+	  }
 
-		    //
-		    // Reset the array, or remove it completely if we have no more listeners.
-		    //
-		    if (events.length) this._events[evt] = events.length === 1 ? events[0] : events;
-		    else clearEvent(this, evt);
-		  }
+	  return this;
+	};
 
-		  return this;
-		};
+	/**
+	 * Remove all listeners, or those of the specified event.
+	 *
+	 * @param {(String|Symbol)} [event] The event name.
+	 * @returns {EventEmitter} \`this\`.
+	 * @public
+	 */
+	EventEmitter.prototype.removeAllListeners = function removeAllListeners(event) {
+	  var evt;
 
-		/**
-		 * Remove all listeners, or those of the specified event.
-		 *
-		 * @param {(String|Symbol)} [event] The event name.
-		 * @returns {EventEmitter} \`this\`.
-		 * @public
-		 */
-		EventEmitter.prototype.removeAllListeners = function removeAllListeners(event) {
-		  var evt;
+	  if (event) {
+	    evt = prefix ? prefix + event : event;
+	    if (this._events[evt]) clearEvent(this, evt);
+	  } else {
+	    this._events = new Events();
+	    this._eventsCount = 0;
+	  }
 
-		  if (event) {
-		    evt = prefix ? prefix + event : event;
-		    if (this._events[evt]) clearEvent(this, evt);
-		  } else {
-		    this._events = new Events();
-		    this._eventsCount = 0;
-		  }
+	  return this;
+	};
 
-		  return this;
-		};
+	//
+	// Alias methods names because people roll like that.
+	//
+	EventEmitter.prototype.off = EventEmitter.prototype.removeListener;
+	EventEmitter.prototype.addListener = EventEmitter.prototype.on;
 
-		//
-		// Alias methods names because people roll like that.
-		//
-		EventEmitter.prototype.off = EventEmitter.prototype.removeListener;
-		EventEmitter.prototype.addListener = EventEmitter.prototype.on;
+	//
+	// Expose the prefix.
+	//
+	EventEmitter.prefixed = prefix;
 
-		//
-		// Expose the prefix.
-		//
-		EventEmitter.prefixed = prefix;
+	//
+	// Allow \`EventEmitter\` to be imported as module namespace.
+	//
+	EventEmitter.EventEmitter = EventEmitter;
 
-		//
-		// Allow \`EventEmitter\` to be imported as module namespace.
-		//
-		EventEmitter.EventEmitter = EventEmitter;
+	//
+	// Expose the module.
+	//
+	{
+	  module.exports = EventEmitter;
+	} 
+} (eventemitter3));
 
-		//
-		// Expose the module.
-		//
-		{
-		  module.exports = EventEmitter;
-		} 
-	} (eventemitter3));
-	return eventemitter3.exports;
-}
-
-var eventemitter3Exports = requireEventemitter3();
+var eventemitter3Exports = eventemitter3.exports;
 var EventEmitter = /*@__PURE__*/getDefaultExportFromCjs(eventemitter3Exports);
 
 // @ts-expect-error -- the dependency is only installed during test
@@ -1017,62 +1098,26 @@ exports[`rollup-plugin-swc3 swc (rollup 2) standalone minify 1`] = `
 `;
 
 exports[`rollup-plugin-swc3 swc (rollup 2) support rollup virtual module (e.g. commonjs plugin) 1`] = `
-"function getDefaultExportFromCjs (x) {
-	return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
-}
+"var rollupCommonjs = {};
 
-var rollupCommonjs = {};
-
-var foo;
-var hasRequiredFoo;
-function requireFoo() {
-    if (hasRequiredFoo) return foo;
-    hasRequiredFoo = 1;
-    foo = 'foo';
-    return foo;
-}
+var foo = 'foo';
 
 var bar = {};
 
-var hasRequiredBar;
-function requireBar() {
-    if (hasRequiredBar) return bar;
-    hasRequiredBar = 1;
-    bar.Bar = 'bar';
-    return bar;
-}
+bar.Bar = 'bar';
 
-var hasRequiredRollupCommonjs;
-function requireRollupCommonjs() {
-    if (hasRequiredRollupCommonjs) return rollupCommonjs;
-    hasRequiredRollupCommonjs = 1;
-    const Foo = requireFoo();
-    const { Bar } = requireBar();
-    console.log(Foo, Bar);
-    return rollupCommonjs;
-}
+const Foo = foo;
+const { Bar } = bar;
+console.log(Foo, Bar);
 
-var rollupCommonjsExports = requireRollupCommonjs();
-var index = /*@__PURE__*/getDefaultExportFromCjs(rollupCommonjsExports);
-
-export { index as default };
+export { rollupCommonjs as default };
 "
 `;
 
 exports[`rollup-plugin-swc3 swc (rollup 2) target - include other files 1`] = `
-"var module = {};
+"var foo = 'sukka';
 
-var hasRequiredModule;
-function requireModule() {
-    if (hasRequiredModule) return module;
-    hasRequiredModule = 1;
-    module.foo = 'sukka';
-    return module;
-}
-
-var moduleExports = requireModule();
-
-console.log(moduleExports.foo);
+console.log(foo);
 "
 `;
 
@@ -1158,7 +1203,7 @@ export { foo };
 "
 `;
 
-exports[`rollup-plugin-swc3 swc (rollup 3) detect  decorator for typescript5 1`] = `
+exports[`rollup-plugin-swc3 swc (rollup 3) detect decorator for typescript5 1`] = `
 "function _array_like_to_array(arr, len) {
     if (len == null || len > arr.length) len = arr.length;
     for(var i = 0, arr2 = new Array(len); i < len; i++)arr2[i] = arr[i];
@@ -1171,6 +1216,20 @@ function _class_call_check(instance, Constructor) {
     if (!(instance instanceof Constructor)) {
         throw new TypeError(\\"Cannot call a class as a function\\");
     }
+}
+function _defineProperties(target, props) {
+    for(var i = 0; i < props.length; i++){
+        var descriptor = props[i];
+        descriptor.enumerable = descriptor.enumerable || false;
+        descriptor.configurable = true;
+        if (\\"value\\" in descriptor) descriptor.writable = true;
+        Object.defineProperty(target, descriptor.key, descriptor);
+    }
+}
+function _create_class(Constructor, protoProps, staticProps) {
+    if (protoProps) _defineProperties(Constructor.prototype, protoProps);
+    if (staticProps) _defineProperties(Constructor, staticProps);
+    return Constructor;
 }
 function _define_property(obj, key, value) {
     if (key in obj) {
@@ -1595,23 +1654,97 @@ function applyDecs2203RFactory() {
 function _apply_decs_2203_r(targetClass, memberDecs, classDecs, parentClass) {
     return (_apply_decs_2203_r = applyDecs2203RFactory())(targetClass, memberDecs, classDecs, parentClass);
 }
-var // @ts-expect-error
-_init_name;
-var printMemberName = function(target, memberName) {
-    console.log(memberName);
-};
-var Person = function Person() {
-    _class_call_check(this, Person);
-    _define_property(this, \\"name\\", _init_name(this, \\"Jon\\"));
-};
+var _initProto;
+function trace(value, param) {
+    var kind = param.kind; param.name;
+    if (kind === 'method') {
+        return function() {
+            for(var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++){
+                args[_key] = arguments[_key];
+            }
+            console.log('trace');
+            return value.apply(this, args);
+        };
+    }
+}
+var People = /*#__PURE__*/ function() {
+    function People() {
+        _class_call_check(this, People);
+        _define_property(this, \\"xzy\\", void 0);
+        _initProto(this);
+        this.xzy = 'xzy';
+    }
+    _create_class(People, [
+        {
+            key: \\"test\\",
+            value: function test() {
+                return this.xzy;
+            }
+        }
+    ]);
+    return People;
+}();
 var ref, ref1;
-ref = _apply_decs_2203_r(Person, [
+ref = _apply_decs_2203_r(People, [
     [
-        printMemberName,
-        0,
-        \\"name\\"
+        trace,
+        2,
+        \\"test\\"
     ]
-], []), ref1 = _sliced_to_array(ref.e, 1), _init_name = ref1[0];
+], []), ref1 = _sliced_to_array(ref.e, 1), _initProto = ref1[0];
+var p = new People();
+p.test();
+"
+`;
+
+exports[`rollup-plugin-swc3 swc (rollup 3) detect legacy decorator for typescript5 1`] = `
+"function _define_property(obj, key, value) {
+    if (key in obj) {
+        Object.defineProperty(obj, key, {
+            value: value,
+            enumerable: true,
+            configurable: true,
+            writable: true
+        });
+    } else {
+        obj[key] = value;
+    }
+    return obj;
+}
+function _ts_decorate(decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === \\"object\\" && typeof Reflect.decorate === \\"function\\") r = Reflect.decorate(decorators, target, key, desc);
+    else for(var i = decorators.length - 1; i >= 0; i--)if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+}
+function _ts_metadata(k, v) {
+    if (typeof Reflect === \\"object\\" && typeof Reflect.metadata === \\"function\\") return Reflect.metadata(k, v);
+}
+function trace(_target, _name, descriptor) {
+    const original = descriptor.value;
+    descriptor.value = function() {
+        console.log('trace');
+        return original.call(this);
+    };
+    return descriptor;
+}
+class People {
+    test() {
+        return this.xzy;
+    }
+    constructor(){
+        _define_property(this, \\"xzy\\", void 0);
+        this.xzy = 'xzy';
+    }
+}
+_ts_decorate([
+    trace,
+    _ts_metadata(\\"design:type\\", Function),
+    _ts_metadata(\\"design:paramtypes\\", []),
+    _ts_metadata(\\"design:returntype\\", void 0)
+], People.prototype, \\"test\\", null);
+const p = new People();
+p.test();
 "
 `;
 
@@ -1666,352 +1799,345 @@ exports[`rollup-plugin-swc3 swc (rollup 3) issue 58 - eventemitter3 1`] = `
 
 var eventemitter3 = {exports: {}};
 
-var hasRequiredEventemitter3;
+(function (module) {
 
-function requireEventemitter3 () {
-	if (hasRequiredEventemitter3) return eventemitter3.exports;
-	hasRequiredEventemitter3 = 1;
-	(function (module) {
+	var has = Object.prototype.hasOwnProperty
+	  , prefix = '~';
 
-		var has = Object.prototype.hasOwnProperty
-		  , prefix = '~';
+	/**
+	 * Constructor to create a storage for our \`EE\` objects.
+	 * An \`Events\` instance is a plain object whose properties are event names.
+	 *
+	 * @constructor
+	 * @private
+	 */
+	function Events() {}
 
-		/**
-		 * Constructor to create a storage for our \`EE\` objects.
-		 * An \`Events\` instance is a plain object whose properties are event names.
-		 *
-		 * @constructor
-		 * @private
-		 */
-		function Events() {}
+	//
+	// We try to not inherit from \`Object.prototype\`. In some engines creating an
+	// instance in this way is faster than calling \`Object.create(null)\` directly.
+	// If \`Object.create(null)\` is not supported we prefix the event names with a
+	// character to make sure that the built-in object properties are not
+	// overridden or used as an attack vector.
+	//
+	if (Object.create) {
+	  Events.prototype = Object.create(null);
 
-		//
-		// We try to not inherit from \`Object.prototype\`. In some engines creating an
-		// instance in this way is faster than calling \`Object.create(null)\` directly.
-		// If \`Object.create(null)\` is not supported we prefix the event names with a
-		// character to make sure that the built-in object properties are not
-		// overridden or used as an attack vector.
-		//
-		if (Object.create) {
-		  Events.prototype = Object.create(null);
+	  //
+	  // This hack is needed because the \`__proto__\` property is still inherited in
+	  // some old browsers like Android 4, iPhone 5.1, Opera 11 and Safari 5.
+	  //
+	  if (!new Events().__proto__) prefix = false;
+	}
 
-		  //
-		  // This hack is needed because the \`__proto__\` property is still inherited in
-		  // some old browsers like Android 4, iPhone 5.1, Opera 11 and Safari 5.
-		  //
-		  if (!new Events().__proto__) prefix = false;
-		}
+	/**
+	 * Representation of a single event listener.
+	 *
+	 * @param {Function} fn The listener function.
+	 * @param {*} context The context to invoke the listener with.
+	 * @param {Boolean} [once=false] Specify if the listener is a one-time listener.
+	 * @constructor
+	 * @private
+	 */
+	function EE(fn, context, once) {
+	  this.fn = fn;
+	  this.context = context;
+	  this.once = once || false;
+	}
 
-		/**
-		 * Representation of a single event listener.
-		 *
-		 * @param {Function} fn The listener function.
-		 * @param {*} context The context to invoke the listener with.
-		 * @param {Boolean} [once=false] Specify if the listener is a one-time listener.
-		 * @constructor
-		 * @private
-		 */
-		function EE(fn, context, once) {
-		  this.fn = fn;
-		  this.context = context;
-		  this.once = once || false;
-		}
+	/**
+	 * Add a listener for a given event.
+	 *
+	 * @param {EventEmitter} emitter Reference to the \`EventEmitter\` instance.
+	 * @param {(String|Symbol)} event The event name.
+	 * @param {Function} fn The listener function.
+	 * @param {*} context The context to invoke the listener with.
+	 * @param {Boolean} once Specify if the listener is a one-time listener.
+	 * @returns {EventEmitter}
+	 * @private
+	 */
+	function addListener(emitter, event, fn, context, once) {
+	  if (typeof fn !== 'function') {
+	    throw new TypeError('The listener must be a function');
+	  }
 
-		/**
-		 * Add a listener for a given event.
-		 *
-		 * @param {EventEmitter} emitter Reference to the \`EventEmitter\` instance.
-		 * @param {(String|Symbol)} event The event name.
-		 * @param {Function} fn The listener function.
-		 * @param {*} context The context to invoke the listener with.
-		 * @param {Boolean} once Specify if the listener is a one-time listener.
-		 * @returns {EventEmitter}
-		 * @private
-		 */
-		function addListener(emitter, event, fn, context, once) {
-		  if (typeof fn !== 'function') {
-		    throw new TypeError('The listener must be a function');
-		  }
+	  var listener = new EE(fn, context || emitter, once)
+	    , evt = prefix ? prefix + event : event;
 
-		  var listener = new EE(fn, context || emitter, once)
-		    , evt = prefix ? prefix + event : event;
+	  if (!emitter._events[evt]) emitter._events[evt] = listener, emitter._eventsCount++;
+	  else if (!emitter._events[evt].fn) emitter._events[evt].push(listener);
+	  else emitter._events[evt] = [emitter._events[evt], listener];
 
-		  if (!emitter._events[evt]) emitter._events[evt] = listener, emitter._eventsCount++;
-		  else if (!emitter._events[evt].fn) emitter._events[evt].push(listener);
-		  else emitter._events[evt] = [emitter._events[evt], listener];
+	  return emitter;
+	}
 
-		  return emitter;
-		}
+	/**
+	 * Clear event by name.
+	 *
+	 * @param {EventEmitter} emitter Reference to the \`EventEmitter\` instance.
+	 * @param {(String|Symbol)} evt The Event name.
+	 * @private
+	 */
+	function clearEvent(emitter, evt) {
+	  if (--emitter._eventsCount === 0) emitter._events = new Events();
+	  else delete emitter._events[evt];
+	}
 
-		/**
-		 * Clear event by name.
-		 *
-		 * @param {EventEmitter} emitter Reference to the \`EventEmitter\` instance.
-		 * @param {(String|Symbol)} evt The Event name.
-		 * @private
-		 */
-		function clearEvent(emitter, evt) {
-		  if (--emitter._eventsCount === 0) emitter._events = new Events();
-		  else delete emitter._events[evt];
-		}
+	/**
+	 * Minimal \`EventEmitter\` interface that is molded against the Node.js
+	 * \`EventEmitter\` interface.
+	 *
+	 * @constructor
+	 * @public
+	 */
+	function EventEmitter() {
+	  this._events = new Events();
+	  this._eventsCount = 0;
+	}
 
-		/**
-		 * Minimal \`EventEmitter\` interface that is molded against the Node.js
-		 * \`EventEmitter\` interface.
-		 *
-		 * @constructor
-		 * @public
-		 */
-		function EventEmitter() {
-		  this._events = new Events();
-		  this._eventsCount = 0;
-		}
+	/**
+	 * Return an array listing the events for which the emitter has registered
+	 * listeners.
+	 *
+	 * @returns {Array}
+	 * @public
+	 */
+	EventEmitter.prototype.eventNames = function eventNames() {
+	  var names = []
+	    , events
+	    , name;
 
-		/**
-		 * Return an array listing the events for which the emitter has registered
-		 * listeners.
-		 *
-		 * @returns {Array}
-		 * @public
-		 */
-		EventEmitter.prototype.eventNames = function eventNames() {
-		  var names = []
-		    , events
-		    , name;
+	  if (this._eventsCount === 0) return names;
 
-		  if (this._eventsCount === 0) return names;
+	  for (name in (events = this._events)) {
+	    if (has.call(events, name)) names.push(prefix ? name.slice(1) : name);
+	  }
 
-		  for (name in (events = this._events)) {
-		    if (has.call(events, name)) names.push(prefix ? name.slice(1) : name);
-		  }
+	  if (Object.getOwnPropertySymbols) {
+	    return names.concat(Object.getOwnPropertySymbols(events));
+	  }
 
-		  if (Object.getOwnPropertySymbols) {
-		    return names.concat(Object.getOwnPropertySymbols(events));
-		  }
+	  return names;
+	};
 
-		  return names;
-		};
+	/**
+	 * Return the listeners registered for a given event.
+	 *
+	 * @param {(String|Symbol)} event The event name.
+	 * @returns {Array} The registered listeners.
+	 * @public
+	 */
+	EventEmitter.prototype.listeners = function listeners(event) {
+	  var evt = prefix ? prefix + event : event
+	    , handlers = this._events[evt];
 
-		/**
-		 * Return the listeners registered for a given event.
-		 *
-		 * @param {(String|Symbol)} event The event name.
-		 * @returns {Array} The registered listeners.
-		 * @public
-		 */
-		EventEmitter.prototype.listeners = function listeners(event) {
-		  var evt = prefix ? prefix + event : event
-		    , handlers = this._events[evt];
+	  if (!handlers) return [];
+	  if (handlers.fn) return [handlers.fn];
 
-		  if (!handlers) return [];
-		  if (handlers.fn) return [handlers.fn];
+	  for (var i = 0, l = handlers.length, ee = new Array(l); i < l; i++) {
+	    ee[i] = handlers[i].fn;
+	  }
 
-		  for (var i = 0, l = handlers.length, ee = new Array(l); i < l; i++) {
-		    ee[i] = handlers[i].fn;
-		  }
+	  return ee;
+	};
 
-		  return ee;
-		};
+	/**
+	 * Return the number of listeners listening to a given event.
+	 *
+	 * @param {(String|Symbol)} event The event name.
+	 * @returns {Number} The number of listeners.
+	 * @public
+	 */
+	EventEmitter.prototype.listenerCount = function listenerCount(event) {
+	  var evt = prefix ? prefix + event : event
+	    , listeners = this._events[evt];
 
-		/**
-		 * Return the number of listeners listening to a given event.
-		 *
-		 * @param {(String|Symbol)} event The event name.
-		 * @returns {Number} The number of listeners.
-		 * @public
-		 */
-		EventEmitter.prototype.listenerCount = function listenerCount(event) {
-		  var evt = prefix ? prefix + event : event
-		    , listeners = this._events[evt];
+	  if (!listeners) return 0;
+	  if (listeners.fn) return 1;
+	  return listeners.length;
+	};
 
-		  if (!listeners) return 0;
-		  if (listeners.fn) return 1;
-		  return listeners.length;
-		};
+	/**
+	 * Calls each of the listeners registered for a given event.
+	 *
+	 * @param {(String|Symbol)} event The event name.
+	 * @returns {Boolean} \`true\` if the event had listeners, else \`false\`.
+	 * @public
+	 */
+	EventEmitter.prototype.emit = function emit(event, a1, a2, a3, a4, a5) {
+	  var evt = prefix ? prefix + event : event;
 
-		/**
-		 * Calls each of the listeners registered for a given event.
-		 *
-		 * @param {(String|Symbol)} event The event name.
-		 * @returns {Boolean} \`true\` if the event had listeners, else \`false\`.
-		 * @public
-		 */
-		EventEmitter.prototype.emit = function emit(event, a1, a2, a3, a4, a5) {
-		  var evt = prefix ? prefix + event : event;
+	  if (!this._events[evt]) return false;
 
-		  if (!this._events[evt]) return false;
+	  var listeners = this._events[evt]
+	    , len = arguments.length
+	    , args
+	    , i;
 
-		  var listeners = this._events[evt]
-		    , len = arguments.length
-		    , args
-		    , i;
+	  if (listeners.fn) {
+	    if (listeners.once) this.removeListener(event, listeners.fn, undefined, true);
 
-		  if (listeners.fn) {
-		    if (listeners.once) this.removeListener(event, listeners.fn, undefined, true);
+	    switch (len) {
+	      case 1: return listeners.fn.call(listeners.context), true;
+	      case 2: return listeners.fn.call(listeners.context, a1), true;
+	      case 3: return listeners.fn.call(listeners.context, a1, a2), true;
+	      case 4: return listeners.fn.call(listeners.context, a1, a2, a3), true;
+	      case 5: return listeners.fn.call(listeners.context, a1, a2, a3, a4), true;
+	      case 6: return listeners.fn.call(listeners.context, a1, a2, a3, a4, a5), true;
+	    }
 
-		    switch (len) {
-		      case 1: return listeners.fn.call(listeners.context), true;
-		      case 2: return listeners.fn.call(listeners.context, a1), true;
-		      case 3: return listeners.fn.call(listeners.context, a1, a2), true;
-		      case 4: return listeners.fn.call(listeners.context, a1, a2, a3), true;
-		      case 5: return listeners.fn.call(listeners.context, a1, a2, a3, a4), true;
-		      case 6: return listeners.fn.call(listeners.context, a1, a2, a3, a4, a5), true;
-		    }
+	    for (i = 1, args = new Array(len -1); i < len; i++) {
+	      args[i - 1] = arguments[i];
+	    }
 
-		    for (i = 1, args = new Array(len -1); i < len; i++) {
-		      args[i - 1] = arguments[i];
-		    }
+	    listeners.fn.apply(listeners.context, args);
+	  } else {
+	    var length = listeners.length
+	      , j;
 
-		    listeners.fn.apply(listeners.context, args);
-		  } else {
-		    var length = listeners.length
-		      , j;
+	    for (i = 0; i < length; i++) {
+	      if (listeners[i].once) this.removeListener(event, listeners[i].fn, undefined, true);
 
-		    for (i = 0; i < length; i++) {
-		      if (listeners[i].once) this.removeListener(event, listeners[i].fn, undefined, true);
+	      switch (len) {
+	        case 1: listeners[i].fn.call(listeners[i].context); break;
+	        case 2: listeners[i].fn.call(listeners[i].context, a1); break;
+	        case 3: listeners[i].fn.call(listeners[i].context, a1, a2); break;
+	        case 4: listeners[i].fn.call(listeners[i].context, a1, a2, a3); break;
+	        default:
+	          if (!args) for (j = 1, args = new Array(len -1); j < len; j++) {
+	            args[j - 1] = arguments[j];
+	          }
 
-		      switch (len) {
-		        case 1: listeners[i].fn.call(listeners[i].context); break;
-		        case 2: listeners[i].fn.call(listeners[i].context, a1); break;
-		        case 3: listeners[i].fn.call(listeners[i].context, a1, a2); break;
-		        case 4: listeners[i].fn.call(listeners[i].context, a1, a2, a3); break;
-		        default:
-		          if (!args) for (j = 1, args = new Array(len -1); j < len; j++) {
-		            args[j - 1] = arguments[j];
-		          }
+	          listeners[i].fn.apply(listeners[i].context, args);
+	      }
+	    }
+	  }
 
-		          listeners[i].fn.apply(listeners[i].context, args);
-		      }
-		    }
-		  }
+	  return true;
+	};
 
-		  return true;
-		};
+	/**
+	 * Add a listener for a given event.
+	 *
+	 * @param {(String|Symbol)} event The event name.
+	 * @param {Function} fn The listener function.
+	 * @param {*} [context=this] The context to invoke the listener with.
+	 * @returns {EventEmitter} \`this\`.
+	 * @public
+	 */
+	EventEmitter.prototype.on = function on(event, fn, context) {
+	  return addListener(this, event, fn, context, false);
+	};
 
-		/**
-		 * Add a listener for a given event.
-		 *
-		 * @param {(String|Symbol)} event The event name.
-		 * @param {Function} fn The listener function.
-		 * @param {*} [context=this] The context to invoke the listener with.
-		 * @returns {EventEmitter} \`this\`.
-		 * @public
-		 */
-		EventEmitter.prototype.on = function on(event, fn, context) {
-		  return addListener(this, event, fn, context, false);
-		};
+	/**
+	 * Add a one-time listener for a given event.
+	 *
+	 * @param {(String|Symbol)} event The event name.
+	 * @param {Function} fn The listener function.
+	 * @param {*} [context=this] The context to invoke the listener with.
+	 * @returns {EventEmitter} \`this\`.
+	 * @public
+	 */
+	EventEmitter.prototype.once = function once(event, fn, context) {
+	  return addListener(this, event, fn, context, true);
+	};
 
-		/**
-		 * Add a one-time listener for a given event.
-		 *
-		 * @param {(String|Symbol)} event The event name.
-		 * @param {Function} fn The listener function.
-		 * @param {*} [context=this] The context to invoke the listener with.
-		 * @returns {EventEmitter} \`this\`.
-		 * @public
-		 */
-		EventEmitter.prototype.once = function once(event, fn, context) {
-		  return addListener(this, event, fn, context, true);
-		};
+	/**
+	 * Remove the listeners of a given event.
+	 *
+	 * @param {(String|Symbol)} event The event name.
+	 * @param {Function} fn Only remove the listeners that match this function.
+	 * @param {*} context Only remove the listeners that have this context.
+	 * @param {Boolean} once Only remove one-time listeners.
+	 * @returns {EventEmitter} \`this\`.
+	 * @public
+	 */
+	EventEmitter.prototype.removeListener = function removeListener(event, fn, context, once) {
+	  var evt = prefix ? prefix + event : event;
 
-		/**
-		 * Remove the listeners of a given event.
-		 *
-		 * @param {(String|Symbol)} event The event name.
-		 * @param {Function} fn Only remove the listeners that match this function.
-		 * @param {*} context Only remove the listeners that have this context.
-		 * @param {Boolean} once Only remove one-time listeners.
-		 * @returns {EventEmitter} \`this\`.
-		 * @public
-		 */
-		EventEmitter.prototype.removeListener = function removeListener(event, fn, context, once) {
-		  var evt = prefix ? prefix + event : event;
+	  if (!this._events[evt]) return this;
+	  if (!fn) {
+	    clearEvent(this, evt);
+	    return this;
+	  }
 
-		  if (!this._events[evt]) return this;
-		  if (!fn) {
-		    clearEvent(this, evt);
-		    return this;
-		  }
+	  var listeners = this._events[evt];
 
-		  var listeners = this._events[evt];
+	  if (listeners.fn) {
+	    if (
+	      listeners.fn === fn &&
+	      (!once || listeners.once) &&
+	      (!context || listeners.context === context)
+	    ) {
+	      clearEvent(this, evt);
+	    }
+	  } else {
+	    for (var i = 0, events = [], length = listeners.length; i < length; i++) {
+	      if (
+	        listeners[i].fn !== fn ||
+	        (once && !listeners[i].once) ||
+	        (context && listeners[i].context !== context)
+	      ) {
+	        events.push(listeners[i]);
+	      }
+	    }
 
-		  if (listeners.fn) {
-		    if (
-		      listeners.fn === fn &&
-		      (!once || listeners.once) &&
-		      (!context || listeners.context === context)
-		    ) {
-		      clearEvent(this, evt);
-		    }
-		  } else {
-		    for (var i = 0, events = [], length = listeners.length; i < length; i++) {
-		      if (
-		        listeners[i].fn !== fn ||
-		        (once && !listeners[i].once) ||
-		        (context && listeners[i].context !== context)
-		      ) {
-		        events.push(listeners[i]);
-		      }
-		    }
+	    //
+	    // Reset the array, or remove it completely if we have no more listeners.
+	    //
+	    if (events.length) this._events[evt] = events.length === 1 ? events[0] : events;
+	    else clearEvent(this, evt);
+	  }
 
-		    //
-		    // Reset the array, or remove it completely if we have no more listeners.
-		    //
-		    if (events.length) this._events[evt] = events.length === 1 ? events[0] : events;
-		    else clearEvent(this, evt);
-		  }
+	  return this;
+	};
 
-		  return this;
-		};
+	/**
+	 * Remove all listeners, or those of the specified event.
+	 *
+	 * @param {(String|Symbol)} [event] The event name.
+	 * @returns {EventEmitter} \`this\`.
+	 * @public
+	 */
+	EventEmitter.prototype.removeAllListeners = function removeAllListeners(event) {
+	  var evt;
 
-		/**
-		 * Remove all listeners, or those of the specified event.
-		 *
-		 * @param {(String|Symbol)} [event] The event name.
-		 * @returns {EventEmitter} \`this\`.
-		 * @public
-		 */
-		EventEmitter.prototype.removeAllListeners = function removeAllListeners(event) {
-		  var evt;
+	  if (event) {
+	    evt = prefix ? prefix + event : event;
+	    if (this._events[evt]) clearEvent(this, evt);
+	  } else {
+	    this._events = new Events();
+	    this._eventsCount = 0;
+	  }
 
-		  if (event) {
-		    evt = prefix ? prefix + event : event;
-		    if (this._events[evt]) clearEvent(this, evt);
-		  } else {
-		    this._events = new Events();
-		    this._eventsCount = 0;
-		  }
+	  return this;
+	};
 
-		  return this;
-		};
+	//
+	// Alias methods names because people roll like that.
+	//
+	EventEmitter.prototype.off = EventEmitter.prototype.removeListener;
+	EventEmitter.prototype.addListener = EventEmitter.prototype.on;
 
-		//
-		// Alias methods names because people roll like that.
-		//
-		EventEmitter.prototype.off = EventEmitter.prototype.removeListener;
-		EventEmitter.prototype.addListener = EventEmitter.prototype.on;
+	//
+	// Expose the prefix.
+	//
+	EventEmitter.prefixed = prefix;
 
-		//
-		// Expose the prefix.
-		//
-		EventEmitter.prefixed = prefix;
+	//
+	// Allow \`EventEmitter\` to be imported as module namespace.
+	//
+	EventEmitter.EventEmitter = EventEmitter;
 
-		//
-		// Allow \`EventEmitter\` to be imported as module namespace.
-		//
-		EventEmitter.EventEmitter = EventEmitter;
+	//
+	// Expose the module.
+	//
+	{
+	  module.exports = EventEmitter;
+	} 
+} (eventemitter3));
 
-		//
-		// Expose the module.
-		//
-		{
-		  module.exports = EventEmitter;
-		} 
-	} (eventemitter3));
-	return eventemitter3.exports;
-}
-
-var eventemitter3Exports = requireEventemitter3();
+var eventemitter3Exports = eventemitter3.exports;
 var EventEmitter = /*@__PURE__*/getDefaultExportFromCjs(eventemitter3Exports);
 
 // @ts-expect-error -- the dependency is only installed during test
@@ -2173,62 +2299,26 @@ exports[`rollup-plugin-swc3 swc (rollup 3) standalone minify 1`] = `
 `;
 
 exports[`rollup-plugin-swc3 swc (rollup 3) support rollup virtual module (e.g. commonjs plugin) 1`] = `
-"function getDefaultExportFromCjs (x) {
-	return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
-}
+"var rollupCommonjs = {};
 
-var rollupCommonjs = {};
-
-var foo;
-var hasRequiredFoo;
-function requireFoo() {
-    if (hasRequiredFoo) return foo;
-    hasRequiredFoo = 1;
-    foo = 'foo';
-    return foo;
-}
+var foo = 'foo';
 
 var bar = {};
 
-var hasRequiredBar;
-function requireBar() {
-    if (hasRequiredBar) return bar;
-    hasRequiredBar = 1;
-    bar.Bar = 'bar';
-    return bar;
-}
+bar.Bar = 'bar';
 
-var hasRequiredRollupCommonjs;
-function requireRollupCommonjs() {
-    if (hasRequiredRollupCommonjs) return rollupCommonjs;
-    hasRequiredRollupCommonjs = 1;
-    const Foo = requireFoo();
-    const { Bar } = requireBar();
-    console.log(Foo, Bar);
-    return rollupCommonjs;
-}
+const Foo = foo;
+const { Bar } = bar;
+console.log(Foo, Bar);
 
-var rollupCommonjsExports = requireRollupCommonjs();
-var index = /*@__PURE__*/getDefaultExportFromCjs(rollupCommonjsExports);
-
-export { index as default };
+export { rollupCommonjs as default };
 "
 `;
 
 exports[`rollup-plugin-swc3 swc (rollup 3) target - include other files 1`] = `
-"var module = {};
+"var foo = 'sukka';
 
-var hasRequiredModule;
-function requireModule() {
-    if (hasRequiredModule) return module;
-    hasRequiredModule = 1;
-    module.foo = 'sukka';
-    return module;
-}
-
-var moduleExports = requireModule();
-
-console.log(moduleExports.foo);
+console.log(foo);
 "
 `;
 
@@ -2314,7 +2404,7 @@ export { foo };
 "
 `;
 
-exports[`rollup-plugin-swc3 swc (rollup 4) detect  decorator for typescript5 1`] = `
+exports[`rollup-plugin-swc3 swc (rollup 4) detect decorator for typescript5 1`] = `
 "function _array_like_to_array(arr, len) {
     if (len == null || len > arr.length) len = arr.length;
     for(var i = 0, arr2 = new Array(len); i < len; i++)arr2[i] = arr[i];
@@ -2327,6 +2417,19 @@ function _class_call_check(instance, Constructor) {
     if (!(instance instanceof Constructor)) {
         throw new TypeError(\\"Cannot call a class as a function\\");
     }
+}
+function _defineProperties(target, props) {
+    for(var i = 0; i < props.length; i++){
+        var descriptor = props[i];
+        descriptor.enumerable = descriptor.enumerable || false;
+        descriptor.configurable = true;
+        if (\\"value\\" in descriptor) descriptor.writable = true;
+        Object.defineProperty(target, descriptor.key, descriptor);
+    }
+}
+function _create_class(Constructor, protoProps, staticProps) {
+    if (protoProps) _defineProperties(Constructor.prototype, protoProps);
+    return Constructor;
 }
 function _define_property(obj, key, value) {
     if (key in obj) {
@@ -2751,23 +2854,97 @@ function applyDecs2203RFactory() {
 function _apply_decs_2203_r(targetClass, memberDecs, classDecs, parentClass) {
     return (_apply_decs_2203_r = applyDecs2203RFactory())(targetClass, memberDecs, classDecs, parentClass);
 }
-var // @ts-expect-error
-_init_name;
-var printMemberName = function(target, memberName) {
-    console.log(memberName);
-};
-var Person = function Person() {
-    _class_call_check(this, Person);
-    _define_property(this, \\"name\\", _init_name(this, \\"Jon\\"));
-};
+var _initProto;
+function trace(value, param) {
+    var kind = param.kind; param.name;
+    if (kind === 'method') {
+        return function() {
+            for(var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++){
+                args[_key] = arguments[_key];
+            }
+            console.log('trace');
+            return value.apply(this, args);
+        };
+    }
+}
+var People = /*#__PURE__*/ function() {
+    function People() {
+        _class_call_check(this, People);
+        _define_property(this, \\"xzy\\", void 0);
+        _initProto(this);
+        this.xzy = 'xzy';
+    }
+    _create_class(People, [
+        {
+            key: \\"test\\",
+            value: function test() {
+                return this.xzy;
+            }
+        }
+    ]);
+    return People;
+}();
 var ref, ref1;
-ref = _apply_decs_2203_r(Person, [
+ref = _apply_decs_2203_r(People, [
     [
-        printMemberName,
-        0,
-        \\"name\\"
+        trace,
+        2,
+        \\"test\\"
     ]
-], []), ref1 = _sliced_to_array(ref.e, 1), _init_name = ref1[0];
+], []), ref1 = _sliced_to_array(ref.e, 1), _initProto = ref1[0];
+var p = new People();
+p.test();
+"
+`;
+
+exports[`rollup-plugin-swc3 swc (rollup 4) detect legacy decorator for typescript5 1`] = `
+"function _define_property(obj, key, value) {
+    if (key in obj) {
+        Object.defineProperty(obj, key, {
+            value: value,
+            enumerable: true,
+            configurable: true,
+            writable: true
+        });
+    } else {
+        obj[key] = value;
+    }
+    return obj;
+}
+function _ts_decorate(decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === \\"object\\" && typeof Reflect.decorate === \\"function\\") r = Reflect.decorate(decorators, target, key, desc);
+    else for(var i = decorators.length - 1; i >= 0; i--)if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+}
+function _ts_metadata(k, v) {
+    if (typeof Reflect === \\"object\\" && typeof Reflect.metadata === \\"function\\") return Reflect.metadata(k, v);
+}
+function trace(_target, _name, descriptor) {
+    const original = descriptor.value;
+    descriptor.value = function() {
+        console.log('trace');
+        return original.call(this);
+    };
+    return descriptor;
+}
+class People {
+    test() {
+        return this.xzy;
+    }
+    constructor(){
+        _define_property(this, \\"xzy\\", void 0);
+        this.xzy = 'xzy';
+    }
+}
+_ts_decorate([
+    trace,
+    _ts_metadata(\\"design:type\\", Function),
+    _ts_metadata(\\"design:paramtypes\\", []),
+    _ts_metadata(\\"design:returntype\\", void 0)
+], People.prototype, \\"test\\", null);
+const p = new People();
+p.test();
 "
 `;
 
@@ -2822,352 +2999,345 @@ exports[`rollup-plugin-swc3 swc (rollup 4) issue 58 - eventemitter3 1`] = `
 
 var eventemitter3 = {exports: {}};
 
-var hasRequiredEventemitter3;
+(function (module) {
 
-function requireEventemitter3 () {
-	if (hasRequiredEventemitter3) return eventemitter3.exports;
-	hasRequiredEventemitter3 = 1;
-	(function (module) {
+	var has = Object.prototype.hasOwnProperty
+	  , prefix = '~';
 
-		var has = Object.prototype.hasOwnProperty
-		  , prefix = '~';
+	/**
+	 * Constructor to create a storage for our \`EE\` objects.
+	 * An \`Events\` instance is a plain object whose properties are event names.
+	 *
+	 * @constructor
+	 * @private
+	 */
+	function Events() {}
 
-		/**
-		 * Constructor to create a storage for our \`EE\` objects.
-		 * An \`Events\` instance is a plain object whose properties are event names.
-		 *
-		 * @constructor
-		 * @private
-		 */
-		function Events() {}
+	//
+	// We try to not inherit from \`Object.prototype\`. In some engines creating an
+	// instance in this way is faster than calling \`Object.create(null)\` directly.
+	// If \`Object.create(null)\` is not supported we prefix the event names with a
+	// character to make sure that the built-in object properties are not
+	// overridden or used as an attack vector.
+	//
+	if (Object.create) {
+	  Events.prototype = Object.create(null);
 
-		//
-		// We try to not inherit from \`Object.prototype\`. In some engines creating an
-		// instance in this way is faster than calling \`Object.create(null)\` directly.
-		// If \`Object.create(null)\` is not supported we prefix the event names with a
-		// character to make sure that the built-in object properties are not
-		// overridden or used as an attack vector.
-		//
-		if (Object.create) {
-		  Events.prototype = Object.create(null);
+	  //
+	  // This hack is needed because the \`__proto__\` property is still inherited in
+	  // some old browsers like Android 4, iPhone 5.1, Opera 11 and Safari 5.
+	  //
+	  if (!new Events().__proto__) prefix = false;
+	}
 
-		  //
-		  // This hack is needed because the \`__proto__\` property is still inherited in
-		  // some old browsers like Android 4, iPhone 5.1, Opera 11 and Safari 5.
-		  //
-		  if (!new Events().__proto__) prefix = false;
-		}
+	/**
+	 * Representation of a single event listener.
+	 *
+	 * @param {Function} fn The listener function.
+	 * @param {*} context The context to invoke the listener with.
+	 * @param {Boolean} [once=false] Specify if the listener is a one-time listener.
+	 * @constructor
+	 * @private
+	 */
+	function EE(fn, context, once) {
+	  this.fn = fn;
+	  this.context = context;
+	  this.once = once || false;
+	}
 
-		/**
-		 * Representation of a single event listener.
-		 *
-		 * @param {Function} fn The listener function.
-		 * @param {*} context The context to invoke the listener with.
-		 * @param {Boolean} [once=false] Specify if the listener is a one-time listener.
-		 * @constructor
-		 * @private
-		 */
-		function EE(fn, context, once) {
-		  this.fn = fn;
-		  this.context = context;
-		  this.once = once || false;
-		}
+	/**
+	 * Add a listener for a given event.
+	 *
+	 * @param {EventEmitter} emitter Reference to the \`EventEmitter\` instance.
+	 * @param {(String|Symbol)} event The event name.
+	 * @param {Function} fn The listener function.
+	 * @param {*} context The context to invoke the listener with.
+	 * @param {Boolean} once Specify if the listener is a one-time listener.
+	 * @returns {EventEmitter}
+	 * @private
+	 */
+	function addListener(emitter, event, fn, context, once) {
+	  if (typeof fn !== 'function') {
+	    throw new TypeError('The listener must be a function');
+	  }
 
-		/**
-		 * Add a listener for a given event.
-		 *
-		 * @param {EventEmitter} emitter Reference to the \`EventEmitter\` instance.
-		 * @param {(String|Symbol)} event The event name.
-		 * @param {Function} fn The listener function.
-		 * @param {*} context The context to invoke the listener with.
-		 * @param {Boolean} once Specify if the listener is a one-time listener.
-		 * @returns {EventEmitter}
-		 * @private
-		 */
-		function addListener(emitter, event, fn, context, once) {
-		  if (typeof fn !== 'function') {
-		    throw new TypeError('The listener must be a function');
-		  }
+	  var listener = new EE(fn, context || emitter, once)
+	    , evt = prefix ? prefix + event : event;
 
-		  var listener = new EE(fn, context || emitter, once)
-		    , evt = prefix ? prefix + event : event;
+	  if (!emitter._events[evt]) emitter._events[evt] = listener, emitter._eventsCount++;
+	  else if (!emitter._events[evt].fn) emitter._events[evt].push(listener);
+	  else emitter._events[evt] = [emitter._events[evt], listener];
 
-		  if (!emitter._events[evt]) emitter._events[evt] = listener, emitter._eventsCount++;
-		  else if (!emitter._events[evt].fn) emitter._events[evt].push(listener);
-		  else emitter._events[evt] = [emitter._events[evt], listener];
+	  return emitter;
+	}
 
-		  return emitter;
-		}
+	/**
+	 * Clear event by name.
+	 *
+	 * @param {EventEmitter} emitter Reference to the \`EventEmitter\` instance.
+	 * @param {(String|Symbol)} evt The Event name.
+	 * @private
+	 */
+	function clearEvent(emitter, evt) {
+	  if (--emitter._eventsCount === 0) emitter._events = new Events();
+	  else delete emitter._events[evt];
+	}
 
-		/**
-		 * Clear event by name.
-		 *
-		 * @param {EventEmitter} emitter Reference to the \`EventEmitter\` instance.
-		 * @param {(String|Symbol)} evt The Event name.
-		 * @private
-		 */
-		function clearEvent(emitter, evt) {
-		  if (--emitter._eventsCount === 0) emitter._events = new Events();
-		  else delete emitter._events[evt];
-		}
+	/**
+	 * Minimal \`EventEmitter\` interface that is molded against the Node.js
+	 * \`EventEmitter\` interface.
+	 *
+	 * @constructor
+	 * @public
+	 */
+	function EventEmitter() {
+	  this._events = new Events();
+	  this._eventsCount = 0;
+	}
 
-		/**
-		 * Minimal \`EventEmitter\` interface that is molded against the Node.js
-		 * \`EventEmitter\` interface.
-		 *
-		 * @constructor
-		 * @public
-		 */
-		function EventEmitter() {
-		  this._events = new Events();
-		  this._eventsCount = 0;
-		}
+	/**
+	 * Return an array listing the events for which the emitter has registered
+	 * listeners.
+	 *
+	 * @returns {Array}
+	 * @public
+	 */
+	EventEmitter.prototype.eventNames = function eventNames() {
+	  var names = []
+	    , events
+	    , name;
 
-		/**
-		 * Return an array listing the events for which the emitter has registered
-		 * listeners.
-		 *
-		 * @returns {Array}
-		 * @public
-		 */
-		EventEmitter.prototype.eventNames = function eventNames() {
-		  var names = []
-		    , events
-		    , name;
+	  if (this._eventsCount === 0) return names;
 
-		  if (this._eventsCount === 0) return names;
+	  for (name in (events = this._events)) {
+	    if (has.call(events, name)) names.push(prefix ? name.slice(1) : name);
+	  }
 
-		  for (name in (events = this._events)) {
-		    if (has.call(events, name)) names.push(prefix ? name.slice(1) : name);
-		  }
+	  if (Object.getOwnPropertySymbols) {
+	    return names.concat(Object.getOwnPropertySymbols(events));
+	  }
 
-		  if (Object.getOwnPropertySymbols) {
-		    return names.concat(Object.getOwnPropertySymbols(events));
-		  }
+	  return names;
+	};
 
-		  return names;
-		};
+	/**
+	 * Return the listeners registered for a given event.
+	 *
+	 * @param {(String|Symbol)} event The event name.
+	 * @returns {Array} The registered listeners.
+	 * @public
+	 */
+	EventEmitter.prototype.listeners = function listeners(event) {
+	  var evt = prefix ? prefix + event : event
+	    , handlers = this._events[evt];
 
-		/**
-		 * Return the listeners registered for a given event.
-		 *
-		 * @param {(String|Symbol)} event The event name.
-		 * @returns {Array} The registered listeners.
-		 * @public
-		 */
-		EventEmitter.prototype.listeners = function listeners(event) {
-		  var evt = prefix ? prefix + event : event
-		    , handlers = this._events[evt];
+	  if (!handlers) return [];
+	  if (handlers.fn) return [handlers.fn];
 
-		  if (!handlers) return [];
-		  if (handlers.fn) return [handlers.fn];
+	  for (var i = 0, l = handlers.length, ee = new Array(l); i < l; i++) {
+	    ee[i] = handlers[i].fn;
+	  }
 
-		  for (var i = 0, l = handlers.length, ee = new Array(l); i < l; i++) {
-		    ee[i] = handlers[i].fn;
-		  }
+	  return ee;
+	};
 
-		  return ee;
-		};
+	/**
+	 * Return the number of listeners listening to a given event.
+	 *
+	 * @param {(String|Symbol)} event The event name.
+	 * @returns {Number} The number of listeners.
+	 * @public
+	 */
+	EventEmitter.prototype.listenerCount = function listenerCount(event) {
+	  var evt = prefix ? prefix + event : event
+	    , listeners = this._events[evt];
 
-		/**
-		 * Return the number of listeners listening to a given event.
-		 *
-		 * @param {(String|Symbol)} event The event name.
-		 * @returns {Number} The number of listeners.
-		 * @public
-		 */
-		EventEmitter.prototype.listenerCount = function listenerCount(event) {
-		  var evt = prefix ? prefix + event : event
-		    , listeners = this._events[evt];
+	  if (!listeners) return 0;
+	  if (listeners.fn) return 1;
+	  return listeners.length;
+	};
 
-		  if (!listeners) return 0;
-		  if (listeners.fn) return 1;
-		  return listeners.length;
-		};
+	/**
+	 * Calls each of the listeners registered for a given event.
+	 *
+	 * @param {(String|Symbol)} event The event name.
+	 * @returns {Boolean} \`true\` if the event had listeners, else \`false\`.
+	 * @public
+	 */
+	EventEmitter.prototype.emit = function emit(event, a1, a2, a3, a4, a5) {
+	  var evt = prefix ? prefix + event : event;
 
-		/**
-		 * Calls each of the listeners registered for a given event.
-		 *
-		 * @param {(String|Symbol)} event The event name.
-		 * @returns {Boolean} \`true\` if the event had listeners, else \`false\`.
-		 * @public
-		 */
-		EventEmitter.prototype.emit = function emit(event, a1, a2, a3, a4, a5) {
-		  var evt = prefix ? prefix + event : event;
+	  if (!this._events[evt]) return false;
 
-		  if (!this._events[evt]) return false;
+	  var listeners = this._events[evt]
+	    , len = arguments.length
+	    , args
+	    , i;
 
-		  var listeners = this._events[evt]
-		    , len = arguments.length
-		    , args
-		    , i;
+	  if (listeners.fn) {
+	    if (listeners.once) this.removeListener(event, listeners.fn, undefined, true);
 
-		  if (listeners.fn) {
-		    if (listeners.once) this.removeListener(event, listeners.fn, undefined, true);
+	    switch (len) {
+	      case 1: return listeners.fn.call(listeners.context), true;
+	      case 2: return listeners.fn.call(listeners.context, a1), true;
+	      case 3: return listeners.fn.call(listeners.context, a1, a2), true;
+	      case 4: return listeners.fn.call(listeners.context, a1, a2, a3), true;
+	      case 5: return listeners.fn.call(listeners.context, a1, a2, a3, a4), true;
+	      case 6: return listeners.fn.call(listeners.context, a1, a2, a3, a4, a5), true;
+	    }
 
-		    switch (len) {
-		      case 1: return listeners.fn.call(listeners.context), true;
-		      case 2: return listeners.fn.call(listeners.context, a1), true;
-		      case 3: return listeners.fn.call(listeners.context, a1, a2), true;
-		      case 4: return listeners.fn.call(listeners.context, a1, a2, a3), true;
-		      case 5: return listeners.fn.call(listeners.context, a1, a2, a3, a4), true;
-		      case 6: return listeners.fn.call(listeners.context, a1, a2, a3, a4, a5), true;
-		    }
+	    for (i = 1, args = new Array(len -1); i < len; i++) {
+	      args[i - 1] = arguments[i];
+	    }
 
-		    for (i = 1, args = new Array(len -1); i < len; i++) {
-		      args[i - 1] = arguments[i];
-		    }
+	    listeners.fn.apply(listeners.context, args);
+	  } else {
+	    var length = listeners.length
+	      , j;
 
-		    listeners.fn.apply(listeners.context, args);
-		  } else {
-		    var length = listeners.length
-		      , j;
+	    for (i = 0; i < length; i++) {
+	      if (listeners[i].once) this.removeListener(event, listeners[i].fn, undefined, true);
 
-		    for (i = 0; i < length; i++) {
-		      if (listeners[i].once) this.removeListener(event, listeners[i].fn, undefined, true);
+	      switch (len) {
+	        case 1: listeners[i].fn.call(listeners[i].context); break;
+	        case 2: listeners[i].fn.call(listeners[i].context, a1); break;
+	        case 3: listeners[i].fn.call(listeners[i].context, a1, a2); break;
+	        case 4: listeners[i].fn.call(listeners[i].context, a1, a2, a3); break;
+	        default:
+	          if (!args) for (j = 1, args = new Array(len -1); j < len; j++) {
+	            args[j - 1] = arguments[j];
+	          }
 
-		      switch (len) {
-		        case 1: listeners[i].fn.call(listeners[i].context); break;
-		        case 2: listeners[i].fn.call(listeners[i].context, a1); break;
-		        case 3: listeners[i].fn.call(listeners[i].context, a1, a2); break;
-		        case 4: listeners[i].fn.call(listeners[i].context, a1, a2, a3); break;
-		        default:
-		          if (!args) for (j = 1, args = new Array(len -1); j < len; j++) {
-		            args[j - 1] = arguments[j];
-		          }
+	          listeners[i].fn.apply(listeners[i].context, args);
+	      }
+	    }
+	  }
 
-		          listeners[i].fn.apply(listeners[i].context, args);
-		      }
-		    }
-		  }
+	  return true;
+	};
 
-		  return true;
-		};
+	/**
+	 * Add a listener for a given event.
+	 *
+	 * @param {(String|Symbol)} event The event name.
+	 * @param {Function} fn The listener function.
+	 * @param {*} [context=this] The context to invoke the listener with.
+	 * @returns {EventEmitter} \`this\`.
+	 * @public
+	 */
+	EventEmitter.prototype.on = function on(event, fn, context) {
+	  return addListener(this, event, fn, context, false);
+	};
 
-		/**
-		 * Add a listener for a given event.
-		 *
-		 * @param {(String|Symbol)} event The event name.
-		 * @param {Function} fn The listener function.
-		 * @param {*} [context=this] The context to invoke the listener with.
-		 * @returns {EventEmitter} \`this\`.
-		 * @public
-		 */
-		EventEmitter.prototype.on = function on(event, fn, context) {
-		  return addListener(this, event, fn, context, false);
-		};
+	/**
+	 * Add a one-time listener for a given event.
+	 *
+	 * @param {(String|Symbol)} event The event name.
+	 * @param {Function} fn The listener function.
+	 * @param {*} [context=this] The context to invoke the listener with.
+	 * @returns {EventEmitter} \`this\`.
+	 * @public
+	 */
+	EventEmitter.prototype.once = function once(event, fn, context) {
+	  return addListener(this, event, fn, context, true);
+	};
 
-		/**
-		 * Add a one-time listener for a given event.
-		 *
-		 * @param {(String|Symbol)} event The event name.
-		 * @param {Function} fn The listener function.
-		 * @param {*} [context=this] The context to invoke the listener with.
-		 * @returns {EventEmitter} \`this\`.
-		 * @public
-		 */
-		EventEmitter.prototype.once = function once(event, fn, context) {
-		  return addListener(this, event, fn, context, true);
-		};
+	/**
+	 * Remove the listeners of a given event.
+	 *
+	 * @param {(String|Symbol)} event The event name.
+	 * @param {Function} fn Only remove the listeners that match this function.
+	 * @param {*} context Only remove the listeners that have this context.
+	 * @param {Boolean} once Only remove one-time listeners.
+	 * @returns {EventEmitter} \`this\`.
+	 * @public
+	 */
+	EventEmitter.prototype.removeListener = function removeListener(event, fn, context, once) {
+	  var evt = prefix ? prefix + event : event;
 
-		/**
-		 * Remove the listeners of a given event.
-		 *
-		 * @param {(String|Symbol)} event The event name.
-		 * @param {Function} fn Only remove the listeners that match this function.
-		 * @param {*} context Only remove the listeners that have this context.
-		 * @param {Boolean} once Only remove one-time listeners.
-		 * @returns {EventEmitter} \`this\`.
-		 * @public
-		 */
-		EventEmitter.prototype.removeListener = function removeListener(event, fn, context, once) {
-		  var evt = prefix ? prefix + event : event;
+	  if (!this._events[evt]) return this;
+	  if (!fn) {
+	    clearEvent(this, evt);
+	    return this;
+	  }
 
-		  if (!this._events[evt]) return this;
-		  if (!fn) {
-		    clearEvent(this, evt);
-		    return this;
-		  }
+	  var listeners = this._events[evt];
 
-		  var listeners = this._events[evt];
+	  if (listeners.fn) {
+	    if (
+	      listeners.fn === fn &&
+	      (!once || listeners.once) &&
+	      (!context || listeners.context === context)
+	    ) {
+	      clearEvent(this, evt);
+	    }
+	  } else {
+	    for (var i = 0, events = [], length = listeners.length; i < length; i++) {
+	      if (
+	        listeners[i].fn !== fn ||
+	        (once && !listeners[i].once) ||
+	        (context && listeners[i].context !== context)
+	      ) {
+	        events.push(listeners[i]);
+	      }
+	    }
 
-		  if (listeners.fn) {
-		    if (
-		      listeners.fn === fn &&
-		      (!once || listeners.once) &&
-		      (!context || listeners.context === context)
-		    ) {
-		      clearEvent(this, evt);
-		    }
-		  } else {
-		    for (var i = 0, events = [], length = listeners.length; i < length; i++) {
-		      if (
-		        listeners[i].fn !== fn ||
-		        (once && !listeners[i].once) ||
-		        (context && listeners[i].context !== context)
-		      ) {
-		        events.push(listeners[i]);
-		      }
-		    }
+	    //
+	    // Reset the array, or remove it completely if we have no more listeners.
+	    //
+	    if (events.length) this._events[evt] = events.length === 1 ? events[0] : events;
+	    else clearEvent(this, evt);
+	  }
 
-		    //
-		    // Reset the array, or remove it completely if we have no more listeners.
-		    //
-		    if (events.length) this._events[evt] = events.length === 1 ? events[0] : events;
-		    else clearEvent(this, evt);
-		  }
+	  return this;
+	};
 
-		  return this;
-		};
+	/**
+	 * Remove all listeners, or those of the specified event.
+	 *
+	 * @param {(String|Symbol)} [event] The event name.
+	 * @returns {EventEmitter} \`this\`.
+	 * @public
+	 */
+	EventEmitter.prototype.removeAllListeners = function removeAllListeners(event) {
+	  var evt;
 
-		/**
-		 * Remove all listeners, or those of the specified event.
-		 *
-		 * @param {(String|Symbol)} [event] The event name.
-		 * @returns {EventEmitter} \`this\`.
-		 * @public
-		 */
-		EventEmitter.prototype.removeAllListeners = function removeAllListeners(event) {
-		  var evt;
+	  if (event) {
+	    evt = prefix ? prefix + event : event;
+	    if (this._events[evt]) clearEvent(this, evt);
+	  } else {
+	    this._events = new Events();
+	    this._eventsCount = 0;
+	  }
 
-		  if (event) {
-		    evt = prefix ? prefix + event : event;
-		    if (this._events[evt]) clearEvent(this, evt);
-		  } else {
-		    this._events = new Events();
-		    this._eventsCount = 0;
-		  }
+	  return this;
+	};
 
-		  return this;
-		};
+	//
+	// Alias methods names because people roll like that.
+	//
+	EventEmitter.prototype.off = EventEmitter.prototype.removeListener;
+	EventEmitter.prototype.addListener = EventEmitter.prototype.on;
 
-		//
-		// Alias methods names because people roll like that.
-		//
-		EventEmitter.prototype.off = EventEmitter.prototype.removeListener;
-		EventEmitter.prototype.addListener = EventEmitter.prototype.on;
+	//
+	// Expose the prefix.
+	//
+	EventEmitter.prefixed = prefix;
 
-		//
-		// Expose the prefix.
-		//
-		EventEmitter.prefixed = prefix;
+	//
+	// Allow \`EventEmitter\` to be imported as module namespace.
+	//
+	EventEmitter.EventEmitter = EventEmitter;
 
-		//
-		// Allow \`EventEmitter\` to be imported as module namespace.
-		//
-		EventEmitter.EventEmitter = EventEmitter;
+	//
+	// Expose the module.
+	//
+	{
+	  module.exports = EventEmitter;
+	} 
+} (eventemitter3));
 
-		//
-		// Expose the module.
-		//
-		{
-		  module.exports = EventEmitter;
-		} 
-	} (eventemitter3));
-	return eventemitter3.exports;
-}
-
-var eventemitter3Exports = requireEventemitter3();
+var eventemitter3Exports = eventemitter3.exports;
 var EventEmitter = /*@__PURE__*/getDefaultExportFromCjs(eventemitter3Exports);
 
 // @ts-expect-error -- the dependency is only installed during test
@@ -3328,62 +3498,26 @@ exports[`rollup-plugin-swc3 swc (rollup 4) standalone minify 1`] = `
 `;
 
 exports[`rollup-plugin-swc3 swc (rollup 4) support rollup virtual module (e.g. commonjs plugin) 1`] = `
-"function getDefaultExportFromCjs (x) {
-	return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
-}
+"var rollupCommonjs = {};
 
-var rollupCommonjs = {};
-
-var foo;
-var hasRequiredFoo;
-function requireFoo() {
-    if (hasRequiredFoo) return foo;
-    hasRequiredFoo = 1;
-    foo = 'foo';
-    return foo;
-}
+var foo = 'foo';
 
 var bar = {};
 
-var hasRequiredBar;
-function requireBar() {
-    if (hasRequiredBar) return bar;
-    hasRequiredBar = 1;
-    bar.Bar = 'bar';
-    return bar;
-}
+bar.Bar = 'bar';
 
-var hasRequiredRollupCommonjs;
-function requireRollupCommonjs() {
-    if (hasRequiredRollupCommonjs) return rollupCommonjs;
-    hasRequiredRollupCommonjs = 1;
-    const Foo = requireFoo();
-    const { Bar } = requireBar();
-    console.log(Foo, Bar);
-    return rollupCommonjs;
-}
+const Foo = foo;
+const { Bar } = bar;
+console.log(Foo, Bar);
 
-var rollupCommonjsExports = requireRollupCommonjs();
-var index = /*@__PURE__*/getDefaultExportFromCjs(rollupCommonjsExports);
-
-export { index as default };
+export { rollupCommonjs as default };
 "
 `;
 
 exports[`rollup-plugin-swc3 swc (rollup 4) target - include other files 1`] = `
-"var module = {};
+"var foo = 'sukka';
 
-var hasRequiredModule;
-function requireModule() {
-    if (hasRequiredModule) return module;
-    hasRequiredModule = 1;
-    module.foo = 'sukka';
-    return module;
-}
-
-var moduleExports = requireModule();
-
-console.log(moduleExports.foo);
+console.log(foo);
 "
 `;
 

--- a/test/__snapshots__/index.ts.snap
+++ b/test/__snapshots__/index.ts.snap
@@ -598,345 +598,352 @@ var eventemitter3 = {exports: {}};
 
 eventemitter3.exports;
 
-(function (module) {
+var hasRequiredEventemitter3;
 
-	var has = Object.prototype.hasOwnProperty
-	  , prefix = '~';
+function requireEventemitter3 () {
+	if (hasRequiredEventemitter3) return eventemitter3.exports;
+	hasRequiredEventemitter3 = 1;
+	(function (module) {
 
-	/**
-	 * Constructor to create a storage for our \`EE\` objects.
-	 * An \`Events\` instance is a plain object whose properties are event names.
-	 *
-	 * @constructor
-	 * @private
-	 */
-	function Events() {}
+		var has = Object.prototype.hasOwnProperty
+		  , prefix = '~';
 
-	//
-	// We try to not inherit from \`Object.prototype\`. In some engines creating an
-	// instance in this way is faster than calling \`Object.create(null)\` directly.
-	// If \`Object.create(null)\` is not supported we prefix the event names with a
-	// character to make sure that the built-in object properties are not
-	// overridden or used as an attack vector.
-	//
-	if (Object.create) {
-	  Events.prototype = Object.create(null);
+		/**
+		 * Constructor to create a storage for our \`EE\` objects.
+		 * An \`Events\` instance is a plain object whose properties are event names.
+		 *
+		 * @constructor
+		 * @private
+		 */
+		function Events() {}
 
-	  //
-	  // This hack is needed because the \`__proto__\` property is still inherited in
-	  // some old browsers like Android 4, iPhone 5.1, Opera 11 and Safari 5.
-	  //
-	  if (!new Events().__proto__) prefix = false;
-	}
+		//
+		// We try to not inherit from \`Object.prototype\`. In some engines creating an
+		// instance in this way is faster than calling \`Object.create(null)\` directly.
+		// If \`Object.create(null)\` is not supported we prefix the event names with a
+		// character to make sure that the built-in object properties are not
+		// overridden or used as an attack vector.
+		//
+		if (Object.create) {
+		  Events.prototype = Object.create(null);
 
-	/**
-	 * Representation of a single event listener.
-	 *
-	 * @param {Function} fn The listener function.
-	 * @param {*} context The context to invoke the listener with.
-	 * @param {Boolean} [once=false] Specify if the listener is a one-time listener.
-	 * @constructor
-	 * @private
-	 */
-	function EE(fn, context, once) {
-	  this.fn = fn;
-	  this.context = context;
-	  this.once = once || false;
-	}
+		  //
+		  // This hack is needed because the \`__proto__\` property is still inherited in
+		  // some old browsers like Android 4, iPhone 5.1, Opera 11 and Safari 5.
+		  //
+		  if (!new Events().__proto__) prefix = false;
+		}
 
-	/**
-	 * Add a listener for a given event.
-	 *
-	 * @param {EventEmitter} emitter Reference to the \`EventEmitter\` instance.
-	 * @param {(String|Symbol)} event The event name.
-	 * @param {Function} fn The listener function.
-	 * @param {*} context The context to invoke the listener with.
-	 * @param {Boolean} once Specify if the listener is a one-time listener.
-	 * @returns {EventEmitter}
-	 * @private
-	 */
-	function addListener(emitter, event, fn, context, once) {
-	  if (typeof fn !== 'function') {
-	    throw new TypeError('The listener must be a function');
-	  }
+		/**
+		 * Representation of a single event listener.
+		 *
+		 * @param {Function} fn The listener function.
+		 * @param {*} context The context to invoke the listener with.
+		 * @param {Boolean} [once=false] Specify if the listener is a one-time listener.
+		 * @constructor
+		 * @private
+		 */
+		function EE(fn, context, once) {
+		  this.fn = fn;
+		  this.context = context;
+		  this.once = once || false;
+		}
 
-	  var listener = new EE(fn, context || emitter, once)
-	    , evt = prefix ? prefix + event : event;
+		/**
+		 * Add a listener for a given event.
+		 *
+		 * @param {EventEmitter} emitter Reference to the \`EventEmitter\` instance.
+		 * @param {(String|Symbol)} event The event name.
+		 * @param {Function} fn The listener function.
+		 * @param {*} context The context to invoke the listener with.
+		 * @param {Boolean} once Specify if the listener is a one-time listener.
+		 * @returns {EventEmitter}
+		 * @private
+		 */
+		function addListener(emitter, event, fn, context, once) {
+		  if (typeof fn !== 'function') {
+		    throw new TypeError('The listener must be a function');
+		  }
 
-	  if (!emitter._events[evt]) emitter._events[evt] = listener, emitter._eventsCount++;
-	  else if (!emitter._events[evt].fn) emitter._events[evt].push(listener);
-	  else emitter._events[evt] = [emitter._events[evt], listener];
+		  var listener = new EE(fn, context || emitter, once)
+		    , evt = prefix ? prefix + event : event;
 
-	  return emitter;
-	}
+		  if (!emitter._events[evt]) emitter._events[evt] = listener, emitter._eventsCount++;
+		  else if (!emitter._events[evt].fn) emitter._events[evt].push(listener);
+		  else emitter._events[evt] = [emitter._events[evt], listener];
 
-	/**
-	 * Clear event by name.
-	 *
-	 * @param {EventEmitter} emitter Reference to the \`EventEmitter\` instance.
-	 * @param {(String|Symbol)} evt The Event name.
-	 * @private
-	 */
-	function clearEvent(emitter, evt) {
-	  if (--emitter._eventsCount === 0) emitter._events = new Events();
-	  else delete emitter._events[evt];
-	}
+		  return emitter;
+		}
 
-	/**
-	 * Minimal \`EventEmitter\` interface that is molded against the Node.js
-	 * \`EventEmitter\` interface.
-	 *
-	 * @constructor
-	 * @public
-	 */
-	function EventEmitter() {
-	  this._events = new Events();
-	  this._eventsCount = 0;
-	}
+		/**
+		 * Clear event by name.
+		 *
+		 * @param {EventEmitter} emitter Reference to the \`EventEmitter\` instance.
+		 * @param {(String|Symbol)} evt The Event name.
+		 * @private
+		 */
+		function clearEvent(emitter, evt) {
+		  if (--emitter._eventsCount === 0) emitter._events = new Events();
+		  else delete emitter._events[evt];
+		}
 
-	/**
-	 * Return an array listing the events for which the emitter has registered
-	 * listeners.
-	 *
-	 * @returns {Array}
-	 * @public
-	 */
-	EventEmitter.prototype.eventNames = function eventNames() {
-	  var names = []
-	    , events
-	    , name;
+		/**
+		 * Minimal \`EventEmitter\` interface that is molded against the Node.js
+		 * \`EventEmitter\` interface.
+		 *
+		 * @constructor
+		 * @public
+		 */
+		function EventEmitter() {
+		  this._events = new Events();
+		  this._eventsCount = 0;
+		}
 
-	  if (this._eventsCount === 0) return names;
+		/**
+		 * Return an array listing the events for which the emitter has registered
+		 * listeners.
+		 *
+		 * @returns {Array}
+		 * @public
+		 */
+		EventEmitter.prototype.eventNames = function eventNames() {
+		  var names = []
+		    , events
+		    , name;
 
-	  for (name in (events = this._events)) {
-	    if (has.call(events, name)) names.push(prefix ? name.slice(1) : name);
-	  }
+		  if (this._eventsCount === 0) return names;
 
-	  if (Object.getOwnPropertySymbols) {
-	    return names.concat(Object.getOwnPropertySymbols(events));
-	  }
+		  for (name in (events = this._events)) {
+		    if (has.call(events, name)) names.push(prefix ? name.slice(1) : name);
+		  }
 
-	  return names;
-	};
+		  if (Object.getOwnPropertySymbols) {
+		    return names.concat(Object.getOwnPropertySymbols(events));
+		  }
 
-	/**
-	 * Return the listeners registered for a given event.
-	 *
-	 * @param {(String|Symbol)} event The event name.
-	 * @returns {Array} The registered listeners.
-	 * @public
-	 */
-	EventEmitter.prototype.listeners = function listeners(event) {
-	  var evt = prefix ? prefix + event : event
-	    , handlers = this._events[evt];
+		  return names;
+		};
 
-	  if (!handlers) return [];
-	  if (handlers.fn) return [handlers.fn];
+		/**
+		 * Return the listeners registered for a given event.
+		 *
+		 * @param {(String|Symbol)} event The event name.
+		 * @returns {Array} The registered listeners.
+		 * @public
+		 */
+		EventEmitter.prototype.listeners = function listeners(event) {
+		  var evt = prefix ? prefix + event : event
+		    , handlers = this._events[evt];
 
-	  for (var i = 0, l = handlers.length, ee = new Array(l); i < l; i++) {
-	    ee[i] = handlers[i].fn;
-	  }
+		  if (!handlers) return [];
+		  if (handlers.fn) return [handlers.fn];
 
-	  return ee;
-	};
+		  for (var i = 0, l = handlers.length, ee = new Array(l); i < l; i++) {
+		    ee[i] = handlers[i].fn;
+		  }
 
-	/**
-	 * Return the number of listeners listening to a given event.
-	 *
-	 * @param {(String|Symbol)} event The event name.
-	 * @returns {Number} The number of listeners.
-	 * @public
-	 */
-	EventEmitter.prototype.listenerCount = function listenerCount(event) {
-	  var evt = prefix ? prefix + event : event
-	    , listeners = this._events[evt];
+		  return ee;
+		};
 
-	  if (!listeners) return 0;
-	  if (listeners.fn) return 1;
-	  return listeners.length;
-	};
+		/**
+		 * Return the number of listeners listening to a given event.
+		 *
+		 * @param {(String|Symbol)} event The event name.
+		 * @returns {Number} The number of listeners.
+		 * @public
+		 */
+		EventEmitter.prototype.listenerCount = function listenerCount(event) {
+		  var evt = prefix ? prefix + event : event
+		    , listeners = this._events[evt];
 
-	/**
-	 * Calls each of the listeners registered for a given event.
-	 *
-	 * @param {(String|Symbol)} event The event name.
-	 * @returns {Boolean} \`true\` if the event had listeners, else \`false\`.
-	 * @public
-	 */
-	EventEmitter.prototype.emit = function emit(event, a1, a2, a3, a4, a5) {
-	  var evt = prefix ? prefix + event : event;
+		  if (!listeners) return 0;
+		  if (listeners.fn) return 1;
+		  return listeners.length;
+		};
 
-	  if (!this._events[evt]) return false;
+		/**
+		 * Calls each of the listeners registered for a given event.
+		 *
+		 * @param {(String|Symbol)} event The event name.
+		 * @returns {Boolean} \`true\` if the event had listeners, else \`false\`.
+		 * @public
+		 */
+		EventEmitter.prototype.emit = function emit(event, a1, a2, a3, a4, a5) {
+		  var evt = prefix ? prefix + event : event;
 
-	  var listeners = this._events[evt]
-	    , len = arguments.length
-	    , args
-	    , i;
+		  if (!this._events[evt]) return false;
 
-	  if (listeners.fn) {
-	    if (listeners.once) this.removeListener(event, listeners.fn, undefined, true);
+		  var listeners = this._events[evt]
+		    , len = arguments.length
+		    , args
+		    , i;
 
-	    switch (len) {
-	      case 1: return listeners.fn.call(listeners.context), true;
-	      case 2: return listeners.fn.call(listeners.context, a1), true;
-	      case 3: return listeners.fn.call(listeners.context, a1, a2), true;
-	      case 4: return listeners.fn.call(listeners.context, a1, a2, a3), true;
-	      case 5: return listeners.fn.call(listeners.context, a1, a2, a3, a4), true;
-	      case 6: return listeners.fn.call(listeners.context, a1, a2, a3, a4, a5), true;
-	    }
+		  if (listeners.fn) {
+		    if (listeners.once) this.removeListener(event, listeners.fn, undefined, true);
 
-	    for (i = 1, args = new Array(len -1); i < len; i++) {
-	      args[i - 1] = arguments[i];
-	    }
+		    switch (len) {
+		      case 1: return listeners.fn.call(listeners.context), true;
+		      case 2: return listeners.fn.call(listeners.context, a1), true;
+		      case 3: return listeners.fn.call(listeners.context, a1, a2), true;
+		      case 4: return listeners.fn.call(listeners.context, a1, a2, a3), true;
+		      case 5: return listeners.fn.call(listeners.context, a1, a2, a3, a4), true;
+		      case 6: return listeners.fn.call(listeners.context, a1, a2, a3, a4, a5), true;
+		    }
 
-	    listeners.fn.apply(listeners.context, args);
-	  } else {
-	    var length = listeners.length
-	      , j;
+		    for (i = 1, args = new Array(len -1); i < len; i++) {
+		      args[i - 1] = arguments[i];
+		    }
 
-	    for (i = 0; i < length; i++) {
-	      if (listeners[i].once) this.removeListener(event, listeners[i].fn, undefined, true);
+		    listeners.fn.apply(listeners.context, args);
+		  } else {
+		    var length = listeners.length
+		      , j;
 
-	      switch (len) {
-	        case 1: listeners[i].fn.call(listeners[i].context); break;
-	        case 2: listeners[i].fn.call(listeners[i].context, a1); break;
-	        case 3: listeners[i].fn.call(listeners[i].context, a1, a2); break;
-	        case 4: listeners[i].fn.call(listeners[i].context, a1, a2, a3); break;
-	        default:
-	          if (!args) for (j = 1, args = new Array(len -1); j < len; j++) {
-	            args[j - 1] = arguments[j];
-	          }
+		    for (i = 0; i < length; i++) {
+		      if (listeners[i].once) this.removeListener(event, listeners[i].fn, undefined, true);
 
-	          listeners[i].fn.apply(listeners[i].context, args);
-	      }
-	    }
-	  }
+		      switch (len) {
+		        case 1: listeners[i].fn.call(listeners[i].context); break;
+		        case 2: listeners[i].fn.call(listeners[i].context, a1); break;
+		        case 3: listeners[i].fn.call(listeners[i].context, a1, a2); break;
+		        case 4: listeners[i].fn.call(listeners[i].context, a1, a2, a3); break;
+		        default:
+		          if (!args) for (j = 1, args = new Array(len -1); j < len; j++) {
+		            args[j - 1] = arguments[j];
+		          }
 
-	  return true;
-	};
+		          listeners[i].fn.apply(listeners[i].context, args);
+		      }
+		    }
+		  }
 
-	/**
-	 * Add a listener for a given event.
-	 *
-	 * @param {(String|Symbol)} event The event name.
-	 * @param {Function} fn The listener function.
-	 * @param {*} [context=this] The context to invoke the listener with.
-	 * @returns {EventEmitter} \`this\`.
-	 * @public
-	 */
-	EventEmitter.prototype.on = function on(event, fn, context) {
-	  return addListener(this, event, fn, context, false);
-	};
+		  return true;
+		};
 
-	/**
-	 * Add a one-time listener for a given event.
-	 *
-	 * @param {(String|Symbol)} event The event name.
-	 * @param {Function} fn The listener function.
-	 * @param {*} [context=this] The context to invoke the listener with.
-	 * @returns {EventEmitter} \`this\`.
-	 * @public
-	 */
-	EventEmitter.prototype.once = function once(event, fn, context) {
-	  return addListener(this, event, fn, context, true);
-	};
+		/**
+		 * Add a listener for a given event.
+		 *
+		 * @param {(String|Symbol)} event The event name.
+		 * @param {Function} fn The listener function.
+		 * @param {*} [context=this] The context to invoke the listener with.
+		 * @returns {EventEmitter} \`this\`.
+		 * @public
+		 */
+		EventEmitter.prototype.on = function on(event, fn, context) {
+		  return addListener(this, event, fn, context, false);
+		};
 
-	/**
-	 * Remove the listeners of a given event.
-	 *
-	 * @param {(String|Symbol)} event The event name.
-	 * @param {Function} fn Only remove the listeners that match this function.
-	 * @param {*} context Only remove the listeners that have this context.
-	 * @param {Boolean} once Only remove one-time listeners.
-	 * @returns {EventEmitter} \`this\`.
-	 * @public
-	 */
-	EventEmitter.prototype.removeListener = function removeListener(event, fn, context, once) {
-	  var evt = prefix ? prefix + event : event;
+		/**
+		 * Add a one-time listener for a given event.
+		 *
+		 * @param {(String|Symbol)} event The event name.
+		 * @param {Function} fn The listener function.
+		 * @param {*} [context=this] The context to invoke the listener with.
+		 * @returns {EventEmitter} \`this\`.
+		 * @public
+		 */
+		EventEmitter.prototype.once = function once(event, fn, context) {
+		  return addListener(this, event, fn, context, true);
+		};
 
-	  if (!this._events[evt]) return this;
-	  if (!fn) {
-	    clearEvent(this, evt);
-	    return this;
-	  }
+		/**
+		 * Remove the listeners of a given event.
+		 *
+		 * @param {(String|Symbol)} event The event name.
+		 * @param {Function} fn Only remove the listeners that match this function.
+		 * @param {*} context Only remove the listeners that have this context.
+		 * @param {Boolean} once Only remove one-time listeners.
+		 * @returns {EventEmitter} \`this\`.
+		 * @public
+		 */
+		EventEmitter.prototype.removeListener = function removeListener(event, fn, context, once) {
+		  var evt = prefix ? prefix + event : event;
 
-	  var listeners = this._events[evt];
+		  if (!this._events[evt]) return this;
+		  if (!fn) {
+		    clearEvent(this, evt);
+		    return this;
+		  }
 
-	  if (listeners.fn) {
-	    if (
-	      listeners.fn === fn &&
-	      (!once || listeners.once) &&
-	      (!context || listeners.context === context)
-	    ) {
-	      clearEvent(this, evt);
-	    }
-	  } else {
-	    for (var i = 0, events = [], length = listeners.length; i < length; i++) {
-	      if (
-	        listeners[i].fn !== fn ||
-	        (once && !listeners[i].once) ||
-	        (context && listeners[i].context !== context)
-	      ) {
-	        events.push(listeners[i]);
-	      }
-	    }
+		  var listeners = this._events[evt];
 
-	    //
-	    // Reset the array, or remove it completely if we have no more listeners.
-	    //
-	    if (events.length) this._events[evt] = events.length === 1 ? events[0] : events;
-	    else clearEvent(this, evt);
-	  }
+		  if (listeners.fn) {
+		    if (
+		      listeners.fn === fn &&
+		      (!once || listeners.once) &&
+		      (!context || listeners.context === context)
+		    ) {
+		      clearEvent(this, evt);
+		    }
+		  } else {
+		    for (var i = 0, events = [], length = listeners.length; i < length; i++) {
+		      if (
+		        listeners[i].fn !== fn ||
+		        (once && !listeners[i].once) ||
+		        (context && listeners[i].context !== context)
+		      ) {
+		        events.push(listeners[i]);
+		      }
+		    }
 
-	  return this;
-	};
+		    //
+		    // Reset the array, or remove it completely if we have no more listeners.
+		    //
+		    if (events.length) this._events[evt] = events.length === 1 ? events[0] : events;
+		    else clearEvent(this, evt);
+		  }
 
-	/**
-	 * Remove all listeners, or those of the specified event.
-	 *
-	 * @param {(String|Symbol)} [event] The event name.
-	 * @returns {EventEmitter} \`this\`.
-	 * @public
-	 */
-	EventEmitter.prototype.removeAllListeners = function removeAllListeners(event) {
-	  var evt;
+		  return this;
+		};
 
-	  if (event) {
-	    evt = prefix ? prefix + event : event;
-	    if (this._events[evt]) clearEvent(this, evt);
-	  } else {
-	    this._events = new Events();
-	    this._eventsCount = 0;
-	  }
+		/**
+		 * Remove all listeners, or those of the specified event.
+		 *
+		 * @param {(String|Symbol)} [event] The event name.
+		 * @returns {EventEmitter} \`this\`.
+		 * @public
+		 */
+		EventEmitter.prototype.removeAllListeners = function removeAllListeners(event) {
+		  var evt;
 
-	  return this;
-	};
+		  if (event) {
+		    evt = prefix ? prefix + event : event;
+		    if (this._events[evt]) clearEvent(this, evt);
+		  } else {
+		    this._events = new Events();
+		    this._eventsCount = 0;
+		  }
 
-	//
-	// Alias methods names because people roll like that.
-	//
-	EventEmitter.prototype.off = EventEmitter.prototype.removeListener;
-	EventEmitter.prototype.addListener = EventEmitter.prototype.on;
+		  return this;
+		};
 
-	//
-	// Expose the prefix.
-	//
-	EventEmitter.prefixed = prefix;
+		//
+		// Alias methods names because people roll like that.
+		//
+		EventEmitter.prototype.off = EventEmitter.prototype.removeListener;
+		EventEmitter.prototype.addListener = EventEmitter.prototype.on;
 
-	//
-	// Allow \`EventEmitter\` to be imported as module namespace.
-	//
-	EventEmitter.EventEmitter = EventEmitter;
+		//
+		// Expose the prefix.
+		//
+		EventEmitter.prefixed = prefix;
 
-	//
-	// Expose the module.
-	//
-	{
-	  module.exports = EventEmitter;
-	} 
-} (eventemitter3));
+		//
+		// Allow \`EventEmitter\` to be imported as module namespace.
+		//
+		EventEmitter.EventEmitter = EventEmitter;
 
-var eventemitter3Exports = eventemitter3.exports;
+		//
+		// Expose the module.
+		//
+		{
+		  module.exports = EventEmitter;
+		} 
+	} (eventemitter3));
+	return eventemitter3.exports;
+}
+
+var eventemitter3Exports = requireEventemitter3();
 var EventEmitter = /*@__PURE__*/getDefaultExportFromCjs(eventemitter3Exports);
 
 // @ts-expect-error -- the dependency is only installed during test
@@ -1098,26 +1105,62 @@ exports[`rollup-plugin-swc3 swc (rollup 2) standalone minify 1`] = `
 `;
 
 exports[`rollup-plugin-swc3 swc (rollup 2) support rollup virtual module (e.g. commonjs plugin) 1`] = `
-"var rollupCommonjs = {};
+"function getDefaultExportFromCjs (x) {
+	return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
+}
 
-var foo = 'foo';
+var rollupCommonjs = {};
+
+var foo;
+var hasRequiredFoo;
+function requireFoo() {
+    if (hasRequiredFoo) return foo;
+    hasRequiredFoo = 1;
+    foo = 'foo';
+    return foo;
+}
 
 var bar = {};
 
-bar.Bar = 'bar';
+var hasRequiredBar;
+function requireBar() {
+    if (hasRequiredBar) return bar;
+    hasRequiredBar = 1;
+    bar.Bar = 'bar';
+    return bar;
+}
 
-const Foo = foo;
-const { Bar } = bar;
-console.log(Foo, Bar);
+var hasRequiredRollupCommonjs;
+function requireRollupCommonjs() {
+    if (hasRequiredRollupCommonjs) return rollupCommonjs;
+    hasRequiredRollupCommonjs = 1;
+    const Foo = requireFoo();
+    const { Bar } = requireBar();
+    console.log(Foo, Bar);
+    return rollupCommonjs;
+}
 
-export { rollupCommonjs as default };
+var rollupCommonjsExports = requireRollupCommonjs();
+var index = /*@__PURE__*/getDefaultExportFromCjs(rollupCommonjsExports);
+
+export { index as default };
 "
 `;
 
 exports[`rollup-plugin-swc3 swc (rollup 2) target - include other files 1`] = `
-"var foo = 'sukka';
+"var module = {};
 
-console.log(foo);
+var hasRequiredModule;
+function requireModule() {
+    if (hasRequiredModule) return module;
+    hasRequiredModule = 1;
+    module.foo = 'sukka';
+    return module;
+}
+
+var moduleExports = requireModule();
+
+console.log(moduleExports.foo);
 "
 `;
 
@@ -1799,345 +1842,352 @@ exports[`rollup-plugin-swc3 swc (rollup 3) issue 58 - eventemitter3 1`] = `
 
 var eventemitter3 = {exports: {}};
 
-(function (module) {
+var hasRequiredEventemitter3;
 
-	var has = Object.prototype.hasOwnProperty
-	  , prefix = '~';
+function requireEventemitter3 () {
+	if (hasRequiredEventemitter3) return eventemitter3.exports;
+	hasRequiredEventemitter3 = 1;
+	(function (module) {
 
-	/**
-	 * Constructor to create a storage for our \`EE\` objects.
-	 * An \`Events\` instance is a plain object whose properties are event names.
-	 *
-	 * @constructor
-	 * @private
-	 */
-	function Events() {}
+		var has = Object.prototype.hasOwnProperty
+		  , prefix = '~';
 
-	//
-	// We try to not inherit from \`Object.prototype\`. In some engines creating an
-	// instance in this way is faster than calling \`Object.create(null)\` directly.
-	// If \`Object.create(null)\` is not supported we prefix the event names with a
-	// character to make sure that the built-in object properties are not
-	// overridden or used as an attack vector.
-	//
-	if (Object.create) {
-	  Events.prototype = Object.create(null);
+		/**
+		 * Constructor to create a storage for our \`EE\` objects.
+		 * An \`Events\` instance is a plain object whose properties are event names.
+		 *
+		 * @constructor
+		 * @private
+		 */
+		function Events() {}
 
-	  //
-	  // This hack is needed because the \`__proto__\` property is still inherited in
-	  // some old browsers like Android 4, iPhone 5.1, Opera 11 and Safari 5.
-	  //
-	  if (!new Events().__proto__) prefix = false;
-	}
+		//
+		// We try to not inherit from \`Object.prototype\`. In some engines creating an
+		// instance in this way is faster than calling \`Object.create(null)\` directly.
+		// If \`Object.create(null)\` is not supported we prefix the event names with a
+		// character to make sure that the built-in object properties are not
+		// overridden or used as an attack vector.
+		//
+		if (Object.create) {
+		  Events.prototype = Object.create(null);
 
-	/**
-	 * Representation of a single event listener.
-	 *
-	 * @param {Function} fn The listener function.
-	 * @param {*} context The context to invoke the listener with.
-	 * @param {Boolean} [once=false] Specify if the listener is a one-time listener.
-	 * @constructor
-	 * @private
-	 */
-	function EE(fn, context, once) {
-	  this.fn = fn;
-	  this.context = context;
-	  this.once = once || false;
-	}
+		  //
+		  // This hack is needed because the \`__proto__\` property is still inherited in
+		  // some old browsers like Android 4, iPhone 5.1, Opera 11 and Safari 5.
+		  //
+		  if (!new Events().__proto__) prefix = false;
+		}
 
-	/**
-	 * Add a listener for a given event.
-	 *
-	 * @param {EventEmitter} emitter Reference to the \`EventEmitter\` instance.
-	 * @param {(String|Symbol)} event The event name.
-	 * @param {Function} fn The listener function.
-	 * @param {*} context The context to invoke the listener with.
-	 * @param {Boolean} once Specify if the listener is a one-time listener.
-	 * @returns {EventEmitter}
-	 * @private
-	 */
-	function addListener(emitter, event, fn, context, once) {
-	  if (typeof fn !== 'function') {
-	    throw new TypeError('The listener must be a function');
-	  }
+		/**
+		 * Representation of a single event listener.
+		 *
+		 * @param {Function} fn The listener function.
+		 * @param {*} context The context to invoke the listener with.
+		 * @param {Boolean} [once=false] Specify if the listener is a one-time listener.
+		 * @constructor
+		 * @private
+		 */
+		function EE(fn, context, once) {
+		  this.fn = fn;
+		  this.context = context;
+		  this.once = once || false;
+		}
 
-	  var listener = new EE(fn, context || emitter, once)
-	    , evt = prefix ? prefix + event : event;
+		/**
+		 * Add a listener for a given event.
+		 *
+		 * @param {EventEmitter} emitter Reference to the \`EventEmitter\` instance.
+		 * @param {(String|Symbol)} event The event name.
+		 * @param {Function} fn The listener function.
+		 * @param {*} context The context to invoke the listener with.
+		 * @param {Boolean} once Specify if the listener is a one-time listener.
+		 * @returns {EventEmitter}
+		 * @private
+		 */
+		function addListener(emitter, event, fn, context, once) {
+		  if (typeof fn !== 'function') {
+		    throw new TypeError('The listener must be a function');
+		  }
 
-	  if (!emitter._events[evt]) emitter._events[evt] = listener, emitter._eventsCount++;
-	  else if (!emitter._events[evt].fn) emitter._events[evt].push(listener);
-	  else emitter._events[evt] = [emitter._events[evt], listener];
+		  var listener = new EE(fn, context || emitter, once)
+		    , evt = prefix ? prefix + event : event;
 
-	  return emitter;
-	}
+		  if (!emitter._events[evt]) emitter._events[evt] = listener, emitter._eventsCount++;
+		  else if (!emitter._events[evt].fn) emitter._events[evt].push(listener);
+		  else emitter._events[evt] = [emitter._events[evt], listener];
 
-	/**
-	 * Clear event by name.
-	 *
-	 * @param {EventEmitter} emitter Reference to the \`EventEmitter\` instance.
-	 * @param {(String|Symbol)} evt The Event name.
-	 * @private
-	 */
-	function clearEvent(emitter, evt) {
-	  if (--emitter._eventsCount === 0) emitter._events = new Events();
-	  else delete emitter._events[evt];
-	}
+		  return emitter;
+		}
 
-	/**
-	 * Minimal \`EventEmitter\` interface that is molded against the Node.js
-	 * \`EventEmitter\` interface.
-	 *
-	 * @constructor
-	 * @public
-	 */
-	function EventEmitter() {
-	  this._events = new Events();
-	  this._eventsCount = 0;
-	}
+		/**
+		 * Clear event by name.
+		 *
+		 * @param {EventEmitter} emitter Reference to the \`EventEmitter\` instance.
+		 * @param {(String|Symbol)} evt The Event name.
+		 * @private
+		 */
+		function clearEvent(emitter, evt) {
+		  if (--emitter._eventsCount === 0) emitter._events = new Events();
+		  else delete emitter._events[evt];
+		}
 
-	/**
-	 * Return an array listing the events for which the emitter has registered
-	 * listeners.
-	 *
-	 * @returns {Array}
-	 * @public
-	 */
-	EventEmitter.prototype.eventNames = function eventNames() {
-	  var names = []
-	    , events
-	    , name;
+		/**
+		 * Minimal \`EventEmitter\` interface that is molded against the Node.js
+		 * \`EventEmitter\` interface.
+		 *
+		 * @constructor
+		 * @public
+		 */
+		function EventEmitter() {
+		  this._events = new Events();
+		  this._eventsCount = 0;
+		}
 
-	  if (this._eventsCount === 0) return names;
+		/**
+		 * Return an array listing the events for which the emitter has registered
+		 * listeners.
+		 *
+		 * @returns {Array}
+		 * @public
+		 */
+		EventEmitter.prototype.eventNames = function eventNames() {
+		  var names = []
+		    , events
+		    , name;
 
-	  for (name in (events = this._events)) {
-	    if (has.call(events, name)) names.push(prefix ? name.slice(1) : name);
-	  }
+		  if (this._eventsCount === 0) return names;
 
-	  if (Object.getOwnPropertySymbols) {
-	    return names.concat(Object.getOwnPropertySymbols(events));
-	  }
+		  for (name in (events = this._events)) {
+		    if (has.call(events, name)) names.push(prefix ? name.slice(1) : name);
+		  }
 
-	  return names;
-	};
+		  if (Object.getOwnPropertySymbols) {
+		    return names.concat(Object.getOwnPropertySymbols(events));
+		  }
 
-	/**
-	 * Return the listeners registered for a given event.
-	 *
-	 * @param {(String|Symbol)} event The event name.
-	 * @returns {Array} The registered listeners.
-	 * @public
-	 */
-	EventEmitter.prototype.listeners = function listeners(event) {
-	  var evt = prefix ? prefix + event : event
-	    , handlers = this._events[evt];
+		  return names;
+		};
 
-	  if (!handlers) return [];
-	  if (handlers.fn) return [handlers.fn];
+		/**
+		 * Return the listeners registered for a given event.
+		 *
+		 * @param {(String|Symbol)} event The event name.
+		 * @returns {Array} The registered listeners.
+		 * @public
+		 */
+		EventEmitter.prototype.listeners = function listeners(event) {
+		  var evt = prefix ? prefix + event : event
+		    , handlers = this._events[evt];
 
-	  for (var i = 0, l = handlers.length, ee = new Array(l); i < l; i++) {
-	    ee[i] = handlers[i].fn;
-	  }
+		  if (!handlers) return [];
+		  if (handlers.fn) return [handlers.fn];
 
-	  return ee;
-	};
+		  for (var i = 0, l = handlers.length, ee = new Array(l); i < l; i++) {
+		    ee[i] = handlers[i].fn;
+		  }
 
-	/**
-	 * Return the number of listeners listening to a given event.
-	 *
-	 * @param {(String|Symbol)} event The event name.
-	 * @returns {Number} The number of listeners.
-	 * @public
-	 */
-	EventEmitter.prototype.listenerCount = function listenerCount(event) {
-	  var evt = prefix ? prefix + event : event
-	    , listeners = this._events[evt];
+		  return ee;
+		};
 
-	  if (!listeners) return 0;
-	  if (listeners.fn) return 1;
-	  return listeners.length;
-	};
+		/**
+		 * Return the number of listeners listening to a given event.
+		 *
+		 * @param {(String|Symbol)} event The event name.
+		 * @returns {Number} The number of listeners.
+		 * @public
+		 */
+		EventEmitter.prototype.listenerCount = function listenerCount(event) {
+		  var evt = prefix ? prefix + event : event
+		    , listeners = this._events[evt];
 
-	/**
-	 * Calls each of the listeners registered for a given event.
-	 *
-	 * @param {(String|Symbol)} event The event name.
-	 * @returns {Boolean} \`true\` if the event had listeners, else \`false\`.
-	 * @public
-	 */
-	EventEmitter.prototype.emit = function emit(event, a1, a2, a3, a4, a5) {
-	  var evt = prefix ? prefix + event : event;
+		  if (!listeners) return 0;
+		  if (listeners.fn) return 1;
+		  return listeners.length;
+		};
 
-	  if (!this._events[evt]) return false;
+		/**
+		 * Calls each of the listeners registered for a given event.
+		 *
+		 * @param {(String|Symbol)} event The event name.
+		 * @returns {Boolean} \`true\` if the event had listeners, else \`false\`.
+		 * @public
+		 */
+		EventEmitter.prototype.emit = function emit(event, a1, a2, a3, a4, a5) {
+		  var evt = prefix ? prefix + event : event;
 
-	  var listeners = this._events[evt]
-	    , len = arguments.length
-	    , args
-	    , i;
+		  if (!this._events[evt]) return false;
 
-	  if (listeners.fn) {
-	    if (listeners.once) this.removeListener(event, listeners.fn, undefined, true);
+		  var listeners = this._events[evt]
+		    , len = arguments.length
+		    , args
+		    , i;
 
-	    switch (len) {
-	      case 1: return listeners.fn.call(listeners.context), true;
-	      case 2: return listeners.fn.call(listeners.context, a1), true;
-	      case 3: return listeners.fn.call(listeners.context, a1, a2), true;
-	      case 4: return listeners.fn.call(listeners.context, a1, a2, a3), true;
-	      case 5: return listeners.fn.call(listeners.context, a1, a2, a3, a4), true;
-	      case 6: return listeners.fn.call(listeners.context, a1, a2, a3, a4, a5), true;
-	    }
+		  if (listeners.fn) {
+		    if (listeners.once) this.removeListener(event, listeners.fn, undefined, true);
 
-	    for (i = 1, args = new Array(len -1); i < len; i++) {
-	      args[i - 1] = arguments[i];
-	    }
+		    switch (len) {
+		      case 1: return listeners.fn.call(listeners.context), true;
+		      case 2: return listeners.fn.call(listeners.context, a1), true;
+		      case 3: return listeners.fn.call(listeners.context, a1, a2), true;
+		      case 4: return listeners.fn.call(listeners.context, a1, a2, a3), true;
+		      case 5: return listeners.fn.call(listeners.context, a1, a2, a3, a4), true;
+		      case 6: return listeners.fn.call(listeners.context, a1, a2, a3, a4, a5), true;
+		    }
 
-	    listeners.fn.apply(listeners.context, args);
-	  } else {
-	    var length = listeners.length
-	      , j;
+		    for (i = 1, args = new Array(len -1); i < len; i++) {
+		      args[i - 1] = arguments[i];
+		    }
 
-	    for (i = 0; i < length; i++) {
-	      if (listeners[i].once) this.removeListener(event, listeners[i].fn, undefined, true);
+		    listeners.fn.apply(listeners.context, args);
+		  } else {
+		    var length = listeners.length
+		      , j;
 
-	      switch (len) {
-	        case 1: listeners[i].fn.call(listeners[i].context); break;
-	        case 2: listeners[i].fn.call(listeners[i].context, a1); break;
-	        case 3: listeners[i].fn.call(listeners[i].context, a1, a2); break;
-	        case 4: listeners[i].fn.call(listeners[i].context, a1, a2, a3); break;
-	        default:
-	          if (!args) for (j = 1, args = new Array(len -1); j < len; j++) {
-	            args[j - 1] = arguments[j];
-	          }
+		    for (i = 0; i < length; i++) {
+		      if (listeners[i].once) this.removeListener(event, listeners[i].fn, undefined, true);
 
-	          listeners[i].fn.apply(listeners[i].context, args);
-	      }
-	    }
-	  }
+		      switch (len) {
+		        case 1: listeners[i].fn.call(listeners[i].context); break;
+		        case 2: listeners[i].fn.call(listeners[i].context, a1); break;
+		        case 3: listeners[i].fn.call(listeners[i].context, a1, a2); break;
+		        case 4: listeners[i].fn.call(listeners[i].context, a1, a2, a3); break;
+		        default:
+		          if (!args) for (j = 1, args = new Array(len -1); j < len; j++) {
+		            args[j - 1] = arguments[j];
+		          }
 
-	  return true;
-	};
+		          listeners[i].fn.apply(listeners[i].context, args);
+		      }
+		    }
+		  }
 
-	/**
-	 * Add a listener for a given event.
-	 *
-	 * @param {(String|Symbol)} event The event name.
-	 * @param {Function} fn The listener function.
-	 * @param {*} [context=this] The context to invoke the listener with.
-	 * @returns {EventEmitter} \`this\`.
-	 * @public
-	 */
-	EventEmitter.prototype.on = function on(event, fn, context) {
-	  return addListener(this, event, fn, context, false);
-	};
+		  return true;
+		};
 
-	/**
-	 * Add a one-time listener for a given event.
-	 *
-	 * @param {(String|Symbol)} event The event name.
-	 * @param {Function} fn The listener function.
-	 * @param {*} [context=this] The context to invoke the listener with.
-	 * @returns {EventEmitter} \`this\`.
-	 * @public
-	 */
-	EventEmitter.prototype.once = function once(event, fn, context) {
-	  return addListener(this, event, fn, context, true);
-	};
+		/**
+		 * Add a listener for a given event.
+		 *
+		 * @param {(String|Symbol)} event The event name.
+		 * @param {Function} fn The listener function.
+		 * @param {*} [context=this] The context to invoke the listener with.
+		 * @returns {EventEmitter} \`this\`.
+		 * @public
+		 */
+		EventEmitter.prototype.on = function on(event, fn, context) {
+		  return addListener(this, event, fn, context, false);
+		};
 
-	/**
-	 * Remove the listeners of a given event.
-	 *
-	 * @param {(String|Symbol)} event The event name.
-	 * @param {Function} fn Only remove the listeners that match this function.
-	 * @param {*} context Only remove the listeners that have this context.
-	 * @param {Boolean} once Only remove one-time listeners.
-	 * @returns {EventEmitter} \`this\`.
-	 * @public
-	 */
-	EventEmitter.prototype.removeListener = function removeListener(event, fn, context, once) {
-	  var evt = prefix ? prefix + event : event;
+		/**
+		 * Add a one-time listener for a given event.
+		 *
+		 * @param {(String|Symbol)} event The event name.
+		 * @param {Function} fn The listener function.
+		 * @param {*} [context=this] The context to invoke the listener with.
+		 * @returns {EventEmitter} \`this\`.
+		 * @public
+		 */
+		EventEmitter.prototype.once = function once(event, fn, context) {
+		  return addListener(this, event, fn, context, true);
+		};
 
-	  if (!this._events[evt]) return this;
-	  if (!fn) {
-	    clearEvent(this, evt);
-	    return this;
-	  }
+		/**
+		 * Remove the listeners of a given event.
+		 *
+		 * @param {(String|Symbol)} event The event name.
+		 * @param {Function} fn Only remove the listeners that match this function.
+		 * @param {*} context Only remove the listeners that have this context.
+		 * @param {Boolean} once Only remove one-time listeners.
+		 * @returns {EventEmitter} \`this\`.
+		 * @public
+		 */
+		EventEmitter.prototype.removeListener = function removeListener(event, fn, context, once) {
+		  var evt = prefix ? prefix + event : event;
 
-	  var listeners = this._events[evt];
+		  if (!this._events[evt]) return this;
+		  if (!fn) {
+		    clearEvent(this, evt);
+		    return this;
+		  }
 
-	  if (listeners.fn) {
-	    if (
-	      listeners.fn === fn &&
-	      (!once || listeners.once) &&
-	      (!context || listeners.context === context)
-	    ) {
-	      clearEvent(this, evt);
-	    }
-	  } else {
-	    for (var i = 0, events = [], length = listeners.length; i < length; i++) {
-	      if (
-	        listeners[i].fn !== fn ||
-	        (once && !listeners[i].once) ||
-	        (context && listeners[i].context !== context)
-	      ) {
-	        events.push(listeners[i]);
-	      }
-	    }
+		  var listeners = this._events[evt];
 
-	    //
-	    // Reset the array, or remove it completely if we have no more listeners.
-	    //
-	    if (events.length) this._events[evt] = events.length === 1 ? events[0] : events;
-	    else clearEvent(this, evt);
-	  }
+		  if (listeners.fn) {
+		    if (
+		      listeners.fn === fn &&
+		      (!once || listeners.once) &&
+		      (!context || listeners.context === context)
+		    ) {
+		      clearEvent(this, evt);
+		    }
+		  } else {
+		    for (var i = 0, events = [], length = listeners.length; i < length; i++) {
+		      if (
+		        listeners[i].fn !== fn ||
+		        (once && !listeners[i].once) ||
+		        (context && listeners[i].context !== context)
+		      ) {
+		        events.push(listeners[i]);
+		      }
+		    }
 
-	  return this;
-	};
+		    //
+		    // Reset the array, or remove it completely if we have no more listeners.
+		    //
+		    if (events.length) this._events[evt] = events.length === 1 ? events[0] : events;
+		    else clearEvent(this, evt);
+		  }
 
-	/**
-	 * Remove all listeners, or those of the specified event.
-	 *
-	 * @param {(String|Symbol)} [event] The event name.
-	 * @returns {EventEmitter} \`this\`.
-	 * @public
-	 */
-	EventEmitter.prototype.removeAllListeners = function removeAllListeners(event) {
-	  var evt;
+		  return this;
+		};
 
-	  if (event) {
-	    evt = prefix ? prefix + event : event;
-	    if (this._events[evt]) clearEvent(this, evt);
-	  } else {
-	    this._events = new Events();
-	    this._eventsCount = 0;
-	  }
+		/**
+		 * Remove all listeners, or those of the specified event.
+		 *
+		 * @param {(String|Symbol)} [event] The event name.
+		 * @returns {EventEmitter} \`this\`.
+		 * @public
+		 */
+		EventEmitter.prototype.removeAllListeners = function removeAllListeners(event) {
+		  var evt;
 
-	  return this;
-	};
+		  if (event) {
+		    evt = prefix ? prefix + event : event;
+		    if (this._events[evt]) clearEvent(this, evt);
+		  } else {
+		    this._events = new Events();
+		    this._eventsCount = 0;
+		  }
 
-	//
-	// Alias methods names because people roll like that.
-	//
-	EventEmitter.prototype.off = EventEmitter.prototype.removeListener;
-	EventEmitter.prototype.addListener = EventEmitter.prototype.on;
+		  return this;
+		};
 
-	//
-	// Expose the prefix.
-	//
-	EventEmitter.prefixed = prefix;
+		//
+		// Alias methods names because people roll like that.
+		//
+		EventEmitter.prototype.off = EventEmitter.prototype.removeListener;
+		EventEmitter.prototype.addListener = EventEmitter.prototype.on;
 
-	//
-	// Allow \`EventEmitter\` to be imported as module namespace.
-	//
-	EventEmitter.EventEmitter = EventEmitter;
+		//
+		// Expose the prefix.
+		//
+		EventEmitter.prefixed = prefix;
 
-	//
-	// Expose the module.
-	//
-	{
-	  module.exports = EventEmitter;
-	} 
-} (eventemitter3));
+		//
+		// Allow \`EventEmitter\` to be imported as module namespace.
+		//
+		EventEmitter.EventEmitter = EventEmitter;
 
-var eventemitter3Exports = eventemitter3.exports;
+		//
+		// Expose the module.
+		//
+		{
+		  module.exports = EventEmitter;
+		} 
+	} (eventemitter3));
+	return eventemitter3.exports;
+}
+
+var eventemitter3Exports = requireEventemitter3();
 var EventEmitter = /*@__PURE__*/getDefaultExportFromCjs(eventemitter3Exports);
 
 // @ts-expect-error -- the dependency is only installed during test
@@ -2299,26 +2349,62 @@ exports[`rollup-plugin-swc3 swc (rollup 3) standalone minify 1`] = `
 `;
 
 exports[`rollup-plugin-swc3 swc (rollup 3) support rollup virtual module (e.g. commonjs plugin) 1`] = `
-"var rollupCommonjs = {};
+"function getDefaultExportFromCjs (x) {
+	return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
+}
 
-var foo = 'foo';
+var rollupCommonjs = {};
+
+var foo;
+var hasRequiredFoo;
+function requireFoo() {
+    if (hasRequiredFoo) return foo;
+    hasRequiredFoo = 1;
+    foo = 'foo';
+    return foo;
+}
 
 var bar = {};
 
-bar.Bar = 'bar';
+var hasRequiredBar;
+function requireBar() {
+    if (hasRequiredBar) return bar;
+    hasRequiredBar = 1;
+    bar.Bar = 'bar';
+    return bar;
+}
 
-const Foo = foo;
-const { Bar } = bar;
-console.log(Foo, Bar);
+var hasRequiredRollupCommonjs;
+function requireRollupCommonjs() {
+    if (hasRequiredRollupCommonjs) return rollupCommonjs;
+    hasRequiredRollupCommonjs = 1;
+    const Foo = requireFoo();
+    const { Bar } = requireBar();
+    console.log(Foo, Bar);
+    return rollupCommonjs;
+}
 
-export { rollupCommonjs as default };
+var rollupCommonjsExports = requireRollupCommonjs();
+var index = /*@__PURE__*/getDefaultExportFromCjs(rollupCommonjsExports);
+
+export { index as default };
 "
 `;
 
 exports[`rollup-plugin-swc3 swc (rollup 3) target - include other files 1`] = `
-"var foo = 'sukka';
+"var module = {};
 
-console.log(foo);
+var hasRequiredModule;
+function requireModule() {
+    if (hasRequiredModule) return module;
+    hasRequiredModule = 1;
+    module.foo = 'sukka';
+    return module;
+}
+
+var moduleExports = requireModule();
+
+console.log(moduleExports.foo);
 "
 `;
 
@@ -2999,345 +3085,352 @@ exports[`rollup-plugin-swc3 swc (rollup 4) issue 58 - eventemitter3 1`] = `
 
 var eventemitter3 = {exports: {}};
 
-(function (module) {
+var hasRequiredEventemitter3;
 
-	var has = Object.prototype.hasOwnProperty
-	  , prefix = '~';
+function requireEventemitter3 () {
+	if (hasRequiredEventemitter3) return eventemitter3.exports;
+	hasRequiredEventemitter3 = 1;
+	(function (module) {
 
-	/**
-	 * Constructor to create a storage for our \`EE\` objects.
-	 * An \`Events\` instance is a plain object whose properties are event names.
-	 *
-	 * @constructor
-	 * @private
-	 */
-	function Events() {}
+		var has = Object.prototype.hasOwnProperty
+		  , prefix = '~';
 
-	//
-	// We try to not inherit from \`Object.prototype\`. In some engines creating an
-	// instance in this way is faster than calling \`Object.create(null)\` directly.
-	// If \`Object.create(null)\` is not supported we prefix the event names with a
-	// character to make sure that the built-in object properties are not
-	// overridden or used as an attack vector.
-	//
-	if (Object.create) {
-	  Events.prototype = Object.create(null);
+		/**
+		 * Constructor to create a storage for our \`EE\` objects.
+		 * An \`Events\` instance is a plain object whose properties are event names.
+		 *
+		 * @constructor
+		 * @private
+		 */
+		function Events() {}
 
-	  //
-	  // This hack is needed because the \`__proto__\` property is still inherited in
-	  // some old browsers like Android 4, iPhone 5.1, Opera 11 and Safari 5.
-	  //
-	  if (!new Events().__proto__) prefix = false;
-	}
+		//
+		// We try to not inherit from \`Object.prototype\`. In some engines creating an
+		// instance in this way is faster than calling \`Object.create(null)\` directly.
+		// If \`Object.create(null)\` is not supported we prefix the event names with a
+		// character to make sure that the built-in object properties are not
+		// overridden or used as an attack vector.
+		//
+		if (Object.create) {
+		  Events.prototype = Object.create(null);
 
-	/**
-	 * Representation of a single event listener.
-	 *
-	 * @param {Function} fn The listener function.
-	 * @param {*} context The context to invoke the listener with.
-	 * @param {Boolean} [once=false] Specify if the listener is a one-time listener.
-	 * @constructor
-	 * @private
-	 */
-	function EE(fn, context, once) {
-	  this.fn = fn;
-	  this.context = context;
-	  this.once = once || false;
-	}
+		  //
+		  // This hack is needed because the \`__proto__\` property is still inherited in
+		  // some old browsers like Android 4, iPhone 5.1, Opera 11 and Safari 5.
+		  //
+		  if (!new Events().__proto__) prefix = false;
+		}
 
-	/**
-	 * Add a listener for a given event.
-	 *
-	 * @param {EventEmitter} emitter Reference to the \`EventEmitter\` instance.
-	 * @param {(String|Symbol)} event The event name.
-	 * @param {Function} fn The listener function.
-	 * @param {*} context The context to invoke the listener with.
-	 * @param {Boolean} once Specify if the listener is a one-time listener.
-	 * @returns {EventEmitter}
-	 * @private
-	 */
-	function addListener(emitter, event, fn, context, once) {
-	  if (typeof fn !== 'function') {
-	    throw new TypeError('The listener must be a function');
-	  }
+		/**
+		 * Representation of a single event listener.
+		 *
+		 * @param {Function} fn The listener function.
+		 * @param {*} context The context to invoke the listener with.
+		 * @param {Boolean} [once=false] Specify if the listener is a one-time listener.
+		 * @constructor
+		 * @private
+		 */
+		function EE(fn, context, once) {
+		  this.fn = fn;
+		  this.context = context;
+		  this.once = once || false;
+		}
 
-	  var listener = new EE(fn, context || emitter, once)
-	    , evt = prefix ? prefix + event : event;
+		/**
+		 * Add a listener for a given event.
+		 *
+		 * @param {EventEmitter} emitter Reference to the \`EventEmitter\` instance.
+		 * @param {(String|Symbol)} event The event name.
+		 * @param {Function} fn The listener function.
+		 * @param {*} context The context to invoke the listener with.
+		 * @param {Boolean} once Specify if the listener is a one-time listener.
+		 * @returns {EventEmitter}
+		 * @private
+		 */
+		function addListener(emitter, event, fn, context, once) {
+		  if (typeof fn !== 'function') {
+		    throw new TypeError('The listener must be a function');
+		  }
 
-	  if (!emitter._events[evt]) emitter._events[evt] = listener, emitter._eventsCount++;
-	  else if (!emitter._events[evt].fn) emitter._events[evt].push(listener);
-	  else emitter._events[evt] = [emitter._events[evt], listener];
+		  var listener = new EE(fn, context || emitter, once)
+		    , evt = prefix ? prefix + event : event;
 
-	  return emitter;
-	}
+		  if (!emitter._events[evt]) emitter._events[evt] = listener, emitter._eventsCount++;
+		  else if (!emitter._events[evt].fn) emitter._events[evt].push(listener);
+		  else emitter._events[evt] = [emitter._events[evt], listener];
 
-	/**
-	 * Clear event by name.
-	 *
-	 * @param {EventEmitter} emitter Reference to the \`EventEmitter\` instance.
-	 * @param {(String|Symbol)} evt The Event name.
-	 * @private
-	 */
-	function clearEvent(emitter, evt) {
-	  if (--emitter._eventsCount === 0) emitter._events = new Events();
-	  else delete emitter._events[evt];
-	}
+		  return emitter;
+		}
 
-	/**
-	 * Minimal \`EventEmitter\` interface that is molded against the Node.js
-	 * \`EventEmitter\` interface.
-	 *
-	 * @constructor
-	 * @public
-	 */
-	function EventEmitter() {
-	  this._events = new Events();
-	  this._eventsCount = 0;
-	}
+		/**
+		 * Clear event by name.
+		 *
+		 * @param {EventEmitter} emitter Reference to the \`EventEmitter\` instance.
+		 * @param {(String|Symbol)} evt The Event name.
+		 * @private
+		 */
+		function clearEvent(emitter, evt) {
+		  if (--emitter._eventsCount === 0) emitter._events = new Events();
+		  else delete emitter._events[evt];
+		}
 
-	/**
-	 * Return an array listing the events for which the emitter has registered
-	 * listeners.
-	 *
-	 * @returns {Array}
-	 * @public
-	 */
-	EventEmitter.prototype.eventNames = function eventNames() {
-	  var names = []
-	    , events
-	    , name;
+		/**
+		 * Minimal \`EventEmitter\` interface that is molded against the Node.js
+		 * \`EventEmitter\` interface.
+		 *
+		 * @constructor
+		 * @public
+		 */
+		function EventEmitter() {
+		  this._events = new Events();
+		  this._eventsCount = 0;
+		}
 
-	  if (this._eventsCount === 0) return names;
+		/**
+		 * Return an array listing the events for which the emitter has registered
+		 * listeners.
+		 *
+		 * @returns {Array}
+		 * @public
+		 */
+		EventEmitter.prototype.eventNames = function eventNames() {
+		  var names = []
+		    , events
+		    , name;
 
-	  for (name in (events = this._events)) {
-	    if (has.call(events, name)) names.push(prefix ? name.slice(1) : name);
-	  }
+		  if (this._eventsCount === 0) return names;
 
-	  if (Object.getOwnPropertySymbols) {
-	    return names.concat(Object.getOwnPropertySymbols(events));
-	  }
+		  for (name in (events = this._events)) {
+		    if (has.call(events, name)) names.push(prefix ? name.slice(1) : name);
+		  }
 
-	  return names;
-	};
+		  if (Object.getOwnPropertySymbols) {
+		    return names.concat(Object.getOwnPropertySymbols(events));
+		  }
 
-	/**
-	 * Return the listeners registered for a given event.
-	 *
-	 * @param {(String|Symbol)} event The event name.
-	 * @returns {Array} The registered listeners.
-	 * @public
-	 */
-	EventEmitter.prototype.listeners = function listeners(event) {
-	  var evt = prefix ? prefix + event : event
-	    , handlers = this._events[evt];
+		  return names;
+		};
 
-	  if (!handlers) return [];
-	  if (handlers.fn) return [handlers.fn];
+		/**
+		 * Return the listeners registered for a given event.
+		 *
+		 * @param {(String|Symbol)} event The event name.
+		 * @returns {Array} The registered listeners.
+		 * @public
+		 */
+		EventEmitter.prototype.listeners = function listeners(event) {
+		  var evt = prefix ? prefix + event : event
+		    , handlers = this._events[evt];
 
-	  for (var i = 0, l = handlers.length, ee = new Array(l); i < l; i++) {
-	    ee[i] = handlers[i].fn;
-	  }
+		  if (!handlers) return [];
+		  if (handlers.fn) return [handlers.fn];
 
-	  return ee;
-	};
+		  for (var i = 0, l = handlers.length, ee = new Array(l); i < l; i++) {
+		    ee[i] = handlers[i].fn;
+		  }
 
-	/**
-	 * Return the number of listeners listening to a given event.
-	 *
-	 * @param {(String|Symbol)} event The event name.
-	 * @returns {Number} The number of listeners.
-	 * @public
-	 */
-	EventEmitter.prototype.listenerCount = function listenerCount(event) {
-	  var evt = prefix ? prefix + event : event
-	    , listeners = this._events[evt];
+		  return ee;
+		};
 
-	  if (!listeners) return 0;
-	  if (listeners.fn) return 1;
-	  return listeners.length;
-	};
+		/**
+		 * Return the number of listeners listening to a given event.
+		 *
+		 * @param {(String|Symbol)} event The event name.
+		 * @returns {Number} The number of listeners.
+		 * @public
+		 */
+		EventEmitter.prototype.listenerCount = function listenerCount(event) {
+		  var evt = prefix ? prefix + event : event
+		    , listeners = this._events[evt];
 
-	/**
-	 * Calls each of the listeners registered for a given event.
-	 *
-	 * @param {(String|Symbol)} event The event name.
-	 * @returns {Boolean} \`true\` if the event had listeners, else \`false\`.
-	 * @public
-	 */
-	EventEmitter.prototype.emit = function emit(event, a1, a2, a3, a4, a5) {
-	  var evt = prefix ? prefix + event : event;
+		  if (!listeners) return 0;
+		  if (listeners.fn) return 1;
+		  return listeners.length;
+		};
 
-	  if (!this._events[evt]) return false;
+		/**
+		 * Calls each of the listeners registered for a given event.
+		 *
+		 * @param {(String|Symbol)} event The event name.
+		 * @returns {Boolean} \`true\` if the event had listeners, else \`false\`.
+		 * @public
+		 */
+		EventEmitter.prototype.emit = function emit(event, a1, a2, a3, a4, a5) {
+		  var evt = prefix ? prefix + event : event;
 
-	  var listeners = this._events[evt]
-	    , len = arguments.length
-	    , args
-	    , i;
+		  if (!this._events[evt]) return false;
 
-	  if (listeners.fn) {
-	    if (listeners.once) this.removeListener(event, listeners.fn, undefined, true);
+		  var listeners = this._events[evt]
+		    , len = arguments.length
+		    , args
+		    , i;
 
-	    switch (len) {
-	      case 1: return listeners.fn.call(listeners.context), true;
-	      case 2: return listeners.fn.call(listeners.context, a1), true;
-	      case 3: return listeners.fn.call(listeners.context, a1, a2), true;
-	      case 4: return listeners.fn.call(listeners.context, a1, a2, a3), true;
-	      case 5: return listeners.fn.call(listeners.context, a1, a2, a3, a4), true;
-	      case 6: return listeners.fn.call(listeners.context, a1, a2, a3, a4, a5), true;
-	    }
+		  if (listeners.fn) {
+		    if (listeners.once) this.removeListener(event, listeners.fn, undefined, true);
 
-	    for (i = 1, args = new Array(len -1); i < len; i++) {
-	      args[i - 1] = arguments[i];
-	    }
+		    switch (len) {
+		      case 1: return listeners.fn.call(listeners.context), true;
+		      case 2: return listeners.fn.call(listeners.context, a1), true;
+		      case 3: return listeners.fn.call(listeners.context, a1, a2), true;
+		      case 4: return listeners.fn.call(listeners.context, a1, a2, a3), true;
+		      case 5: return listeners.fn.call(listeners.context, a1, a2, a3, a4), true;
+		      case 6: return listeners.fn.call(listeners.context, a1, a2, a3, a4, a5), true;
+		    }
 
-	    listeners.fn.apply(listeners.context, args);
-	  } else {
-	    var length = listeners.length
-	      , j;
+		    for (i = 1, args = new Array(len -1); i < len; i++) {
+		      args[i - 1] = arguments[i];
+		    }
 
-	    for (i = 0; i < length; i++) {
-	      if (listeners[i].once) this.removeListener(event, listeners[i].fn, undefined, true);
+		    listeners.fn.apply(listeners.context, args);
+		  } else {
+		    var length = listeners.length
+		      , j;
 
-	      switch (len) {
-	        case 1: listeners[i].fn.call(listeners[i].context); break;
-	        case 2: listeners[i].fn.call(listeners[i].context, a1); break;
-	        case 3: listeners[i].fn.call(listeners[i].context, a1, a2); break;
-	        case 4: listeners[i].fn.call(listeners[i].context, a1, a2, a3); break;
-	        default:
-	          if (!args) for (j = 1, args = new Array(len -1); j < len; j++) {
-	            args[j - 1] = arguments[j];
-	          }
+		    for (i = 0; i < length; i++) {
+		      if (listeners[i].once) this.removeListener(event, listeners[i].fn, undefined, true);
 
-	          listeners[i].fn.apply(listeners[i].context, args);
-	      }
-	    }
-	  }
+		      switch (len) {
+		        case 1: listeners[i].fn.call(listeners[i].context); break;
+		        case 2: listeners[i].fn.call(listeners[i].context, a1); break;
+		        case 3: listeners[i].fn.call(listeners[i].context, a1, a2); break;
+		        case 4: listeners[i].fn.call(listeners[i].context, a1, a2, a3); break;
+		        default:
+		          if (!args) for (j = 1, args = new Array(len -1); j < len; j++) {
+		            args[j - 1] = arguments[j];
+		          }
 
-	  return true;
-	};
+		          listeners[i].fn.apply(listeners[i].context, args);
+		      }
+		    }
+		  }
 
-	/**
-	 * Add a listener for a given event.
-	 *
-	 * @param {(String|Symbol)} event The event name.
-	 * @param {Function} fn The listener function.
-	 * @param {*} [context=this] The context to invoke the listener with.
-	 * @returns {EventEmitter} \`this\`.
-	 * @public
-	 */
-	EventEmitter.prototype.on = function on(event, fn, context) {
-	  return addListener(this, event, fn, context, false);
-	};
+		  return true;
+		};
 
-	/**
-	 * Add a one-time listener for a given event.
-	 *
-	 * @param {(String|Symbol)} event The event name.
-	 * @param {Function} fn The listener function.
-	 * @param {*} [context=this] The context to invoke the listener with.
-	 * @returns {EventEmitter} \`this\`.
-	 * @public
-	 */
-	EventEmitter.prototype.once = function once(event, fn, context) {
-	  return addListener(this, event, fn, context, true);
-	};
+		/**
+		 * Add a listener for a given event.
+		 *
+		 * @param {(String|Symbol)} event The event name.
+		 * @param {Function} fn The listener function.
+		 * @param {*} [context=this] The context to invoke the listener with.
+		 * @returns {EventEmitter} \`this\`.
+		 * @public
+		 */
+		EventEmitter.prototype.on = function on(event, fn, context) {
+		  return addListener(this, event, fn, context, false);
+		};
 
-	/**
-	 * Remove the listeners of a given event.
-	 *
-	 * @param {(String|Symbol)} event The event name.
-	 * @param {Function} fn Only remove the listeners that match this function.
-	 * @param {*} context Only remove the listeners that have this context.
-	 * @param {Boolean} once Only remove one-time listeners.
-	 * @returns {EventEmitter} \`this\`.
-	 * @public
-	 */
-	EventEmitter.prototype.removeListener = function removeListener(event, fn, context, once) {
-	  var evt = prefix ? prefix + event : event;
+		/**
+		 * Add a one-time listener for a given event.
+		 *
+		 * @param {(String|Symbol)} event The event name.
+		 * @param {Function} fn The listener function.
+		 * @param {*} [context=this] The context to invoke the listener with.
+		 * @returns {EventEmitter} \`this\`.
+		 * @public
+		 */
+		EventEmitter.prototype.once = function once(event, fn, context) {
+		  return addListener(this, event, fn, context, true);
+		};
 
-	  if (!this._events[evt]) return this;
-	  if (!fn) {
-	    clearEvent(this, evt);
-	    return this;
-	  }
+		/**
+		 * Remove the listeners of a given event.
+		 *
+		 * @param {(String|Symbol)} event The event name.
+		 * @param {Function} fn Only remove the listeners that match this function.
+		 * @param {*} context Only remove the listeners that have this context.
+		 * @param {Boolean} once Only remove one-time listeners.
+		 * @returns {EventEmitter} \`this\`.
+		 * @public
+		 */
+		EventEmitter.prototype.removeListener = function removeListener(event, fn, context, once) {
+		  var evt = prefix ? prefix + event : event;
 
-	  var listeners = this._events[evt];
+		  if (!this._events[evt]) return this;
+		  if (!fn) {
+		    clearEvent(this, evt);
+		    return this;
+		  }
 
-	  if (listeners.fn) {
-	    if (
-	      listeners.fn === fn &&
-	      (!once || listeners.once) &&
-	      (!context || listeners.context === context)
-	    ) {
-	      clearEvent(this, evt);
-	    }
-	  } else {
-	    for (var i = 0, events = [], length = listeners.length; i < length; i++) {
-	      if (
-	        listeners[i].fn !== fn ||
-	        (once && !listeners[i].once) ||
-	        (context && listeners[i].context !== context)
-	      ) {
-	        events.push(listeners[i]);
-	      }
-	    }
+		  var listeners = this._events[evt];
 
-	    //
-	    // Reset the array, or remove it completely if we have no more listeners.
-	    //
-	    if (events.length) this._events[evt] = events.length === 1 ? events[0] : events;
-	    else clearEvent(this, evt);
-	  }
+		  if (listeners.fn) {
+		    if (
+		      listeners.fn === fn &&
+		      (!once || listeners.once) &&
+		      (!context || listeners.context === context)
+		    ) {
+		      clearEvent(this, evt);
+		    }
+		  } else {
+		    for (var i = 0, events = [], length = listeners.length; i < length; i++) {
+		      if (
+		        listeners[i].fn !== fn ||
+		        (once && !listeners[i].once) ||
+		        (context && listeners[i].context !== context)
+		      ) {
+		        events.push(listeners[i]);
+		      }
+		    }
 
-	  return this;
-	};
+		    //
+		    // Reset the array, or remove it completely if we have no more listeners.
+		    //
+		    if (events.length) this._events[evt] = events.length === 1 ? events[0] : events;
+		    else clearEvent(this, evt);
+		  }
 
-	/**
-	 * Remove all listeners, or those of the specified event.
-	 *
-	 * @param {(String|Symbol)} [event] The event name.
-	 * @returns {EventEmitter} \`this\`.
-	 * @public
-	 */
-	EventEmitter.prototype.removeAllListeners = function removeAllListeners(event) {
-	  var evt;
+		  return this;
+		};
 
-	  if (event) {
-	    evt = prefix ? prefix + event : event;
-	    if (this._events[evt]) clearEvent(this, evt);
-	  } else {
-	    this._events = new Events();
-	    this._eventsCount = 0;
-	  }
+		/**
+		 * Remove all listeners, or those of the specified event.
+		 *
+		 * @param {(String|Symbol)} [event] The event name.
+		 * @returns {EventEmitter} \`this\`.
+		 * @public
+		 */
+		EventEmitter.prototype.removeAllListeners = function removeAllListeners(event) {
+		  var evt;
 
-	  return this;
-	};
+		  if (event) {
+		    evt = prefix ? prefix + event : event;
+		    if (this._events[evt]) clearEvent(this, evt);
+		  } else {
+		    this._events = new Events();
+		    this._eventsCount = 0;
+		  }
 
-	//
-	// Alias methods names because people roll like that.
-	//
-	EventEmitter.prototype.off = EventEmitter.prototype.removeListener;
-	EventEmitter.prototype.addListener = EventEmitter.prototype.on;
+		  return this;
+		};
 
-	//
-	// Expose the prefix.
-	//
-	EventEmitter.prefixed = prefix;
+		//
+		// Alias methods names because people roll like that.
+		//
+		EventEmitter.prototype.off = EventEmitter.prototype.removeListener;
+		EventEmitter.prototype.addListener = EventEmitter.prototype.on;
 
-	//
-	// Allow \`EventEmitter\` to be imported as module namespace.
-	//
-	EventEmitter.EventEmitter = EventEmitter;
+		//
+		// Expose the prefix.
+		//
+		EventEmitter.prefixed = prefix;
 
-	//
-	// Expose the module.
-	//
-	{
-	  module.exports = EventEmitter;
-	} 
-} (eventemitter3));
+		//
+		// Allow \`EventEmitter\` to be imported as module namespace.
+		//
+		EventEmitter.EventEmitter = EventEmitter;
 
-var eventemitter3Exports = eventemitter3.exports;
+		//
+		// Expose the module.
+		//
+		{
+		  module.exports = EventEmitter;
+		} 
+	} (eventemitter3));
+	return eventemitter3.exports;
+}
+
+var eventemitter3Exports = requireEventemitter3();
 var EventEmitter = /*@__PURE__*/getDefaultExportFromCjs(eventemitter3Exports);
 
 // @ts-expect-error -- the dependency is only installed during test
@@ -3498,26 +3591,62 @@ exports[`rollup-plugin-swc3 swc (rollup 4) standalone minify 1`] = `
 `;
 
 exports[`rollup-plugin-swc3 swc (rollup 4) support rollup virtual module (e.g. commonjs plugin) 1`] = `
-"var rollupCommonjs = {};
+"function getDefaultExportFromCjs (x) {
+	return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
+}
 
-var foo = 'foo';
+var rollupCommonjs = {};
+
+var foo;
+var hasRequiredFoo;
+function requireFoo() {
+    if (hasRequiredFoo) return foo;
+    hasRequiredFoo = 1;
+    foo = 'foo';
+    return foo;
+}
 
 var bar = {};
 
-bar.Bar = 'bar';
+var hasRequiredBar;
+function requireBar() {
+    if (hasRequiredBar) return bar;
+    hasRequiredBar = 1;
+    bar.Bar = 'bar';
+    return bar;
+}
 
-const Foo = foo;
-const { Bar } = bar;
-console.log(Foo, Bar);
+var hasRequiredRollupCommonjs;
+function requireRollupCommonjs() {
+    if (hasRequiredRollupCommonjs) return rollupCommonjs;
+    hasRequiredRollupCommonjs = 1;
+    const Foo = requireFoo();
+    const { Bar } = requireBar();
+    console.log(Foo, Bar);
+    return rollupCommonjs;
+}
 
-export { rollupCommonjs as default };
+var rollupCommonjsExports = requireRollupCommonjs();
+var index = /*@__PURE__*/getDefaultExportFromCjs(rollupCommonjsExports);
+
+export { index as default };
 "
 `;
 
 exports[`rollup-plugin-swc3 swc (rollup 4) target - include other files 1`] = `
-"var foo = 'sukka';
+"var module = {};
 
-console.log(foo);
+var hasRequiredModule;
+function requireModule() {
+    if (hasRequiredModule) return module;
+    hasRequiredModule = 1;
+    module.foo = 'sukka';
+    return module;
+}
+
+var moduleExports = requireModule();
+
+console.log(moduleExports.foo);
 "
 `;
 

--- a/test/fixtures/decorators/index.ts
+++ b/test/fixtures/decorators/index.ts
@@ -1,9 +1,23 @@
-const printMemberName = (target: any, memberName: string) => {
-    console.log(memberName);
-  };
-  
-class Person {
-    // @ts-expect-error
-    @printMemberName
-    name: string = "Jon";
+function trace(value, {kind, name}) {
+  if (kind === 'method') {
+    return function (...args) {
+      console.log('trace')
+      return value.apply(this, args);
+    };
+  }
 }
+
+class People {
+  xzy: string
+  constructor(){
+    this.xzy = 'xzy';
+  }
+  @trace
+  test() {
+    return this.xzy
+  }
+}
+
+const p = new People();
+
+p.test();

--- a/test/fixtures/legacy-decorators/index.ts
+++ b/test/fixtures/legacy-decorators/index.ts
@@ -1,0 +1,25 @@
+function trace(_target: any, _name: string, descriptor: PropertyDescriptor) {
+  const original = descriptor.value;
+  descriptor.value = function () {
+    console.log('trace');
+    return original.call(this);
+  };
+
+  return descriptor;
+}
+
+class People {
+  xzy: string;
+  constructor() {
+    this.xzy = 'xzy';
+  }
+
+  @trace
+  test() {
+    return this.xzy;
+  }
+}
+
+const p = new People();
+
+p.test();

--- a/test/fixtures/legacy-decorators/tsconfig.json
+++ b/test/fixtures/legacy-decorators/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "module": "ES2022",
+    "baseUrl": "./"
+  }
+}

--- a/test/index.ts
+++ b/test/index.ts
@@ -376,11 +376,19 @@ const tests = (rollupImpl: typeof rollup2 | typeof rollup3 | typeof rollup4, iso
     ))[0].code.should.matchSnapshot();
   });
 
-  it('detect  decorator for typescript5', async () => {
+  it('detect decorator for typescript5', async () => {
     const dir = await fixture('decorators');
     (await build(
       rollupImpl,
       { tsconfig: false },
+      { input: './index.ts', dir }
+    ))[0].code.should.matchSnapshot();
+  });
+  it('detect legacy decorator for typescript5', async () => {
+    const dir = await fixture('legacy-decorators');
+    (await build(
+      rollupImpl,
+      {},
       { input: './index.ts', dir }
     ))[0].code.should.matchSnapshot();
   });


### PR DESCRIPTION
# TL;DR

In `typescript@5.x` the default decorators is using stage3, but it allowed using legacy decorators. [difference](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-0.html#differences-with-experimental-legacy-decorators) This pull request fix fixes the wrong decorators setting and update legacy decorators unit test suite.



### Relative

#66 